### PR TITLE
feat: implement admin moderation and settings

### DIFF
--- a/components/AdminNav.tsx
+++ b/components/AdminNav.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+
+const AdminNav = () => {
+  return (
+    <nav className="flex gap-4 mb-4">
+      <Link href="/admin/posts">Posts</Link>
+      <Link href="/admin/categories">Kategorien</Link>
+      <Link href="/admin/tags">Tags</Link>
+      <Link href="/admin/comments">Kommentare</Link>
+      <Link href="/admin/settings">Einstellungen</Link>
+    </nav>
+  );
+};
+
+export default AdminNav;

--- a/components/PostForm.tsx
+++ b/components/PostForm.tsx
@@ -1,5 +1,97 @@
-const PostForm = () => {
-  return <div>PostForm Placeholder</div>;
+import { FormEvent, useEffect, useState } from 'react';
+
+interface Category {
+  id: number;
+  name: string;
+}
+
+interface Tag {
+  id: number;
+  name: string;
+}
+
+const PostForm = ({ onSuccess }: { onSuccess: () => void }) => {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [categoryId, setCategoryId] = useState<number | undefined>();
+  const [tagIds, setTagIds] = useState<number[]>([]);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [tags, setTags] = useState<Tag[]>([]);
+
+  useEffect(() => {
+    fetch('/api/categories')
+      .then((res) => res.json())
+      .then(setCategories);
+    fetch('/api/tags')
+      .then((res) => res.json())
+      .then(setTags);
+  }, []);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/posts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, content, categoryId, tagIds }),
+    });
+    setTitle('');
+    setContent('');
+    setCategoryId(undefined);
+    setTagIds([]);
+    onSuccess();
+  };
+
+  const toggleTag = (id: number) => {
+    setTagIds((prev) =>
+      prev.includes(id) ? prev.filter((t) => t !== id) : [...prev, id]
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2 mb-4">
+      <input
+        className="border p-2"
+        placeholder="Titel"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+      />
+      <textarea
+        className="border p-2"
+        placeholder="Inhalt"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+      />
+      <select
+        className="border p-2"
+        value={categoryId ?? ''}
+        onChange={(e) =>
+          setCategoryId(e.target.value ? Number(e.target.value) : undefined)
+        }
+      >
+        <option value="">Kategorie wählen</option>
+        {categories.map((cat) => (
+          <option key={cat.id} value={cat.id}>
+            {cat.name}
+          </option>
+        ))}
+      </select>
+      <div className="flex flex-wrap gap-2">
+        {tags.map((tag) => (
+          <label key={tag.id} className="flex items-center gap-1">
+            <input
+              type="checkbox"
+              checked={tagIds.includes(tag.id)}
+              onChange={() => toggleTag(tag.id)}
+            />
+            {tag.name}
+          </label>
+        ))}
+      </div>
+      <button type="submit" className="bg-blue-500 text-white p-2">
+        Speichern
+      </button>
+    </form>
+  );
 };
 
 export default PostForm;

--- a/components/PostList.tsx
+++ b/components/PostList.tsx
@@ -1,5 +1,35 @@
-const PostList = () => {
-  return <div>PostList Placeholder</div>;
+interface Post {
+  id: number;
+  title: string;
+  category?: { name: string } | null;
+  tags: { id: number; name: string }[];
+}
+
+const PostList = ({ posts, onDelete }: { posts: Post[]; onDelete: (id: number) => void }) => {
+  if (!posts.length) return <p>Keine Beiträge vorhanden.</p>;
+  return (
+    <ul className="flex flex-col gap-2">
+      {posts.map((post) => (
+        <li key={post.id} className="border p-2 flex justify-between items-center">
+          <div>
+            <h3 className="font-semibold">{post.title}</h3>
+            {post.category && <p className="text-sm">Kategorie: {post.category.name}</p>}
+            {post.tags.length > 0 && (
+              <p className="text-sm">
+                Tags: {post.tags.map((t) => t.name).join(', ')}
+              </p>
+            )}
+          </div>
+          <button
+            onClick={() => onDelete(post.id)}
+            className="text-red-600"
+          >
+            Löschen
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
 };
 
 export default PostList;

--- a/pages/admin/categories.tsx
+++ b/pages/admin/categories.tsx
@@ -1,0 +1,79 @@
+import { getSession } from 'next-auth/react';
+import { FormEvent, useEffect, useState } from 'react';
+import AdminNav from '../../components/AdminNav';
+
+interface Category {
+  id: number;
+  name: string;
+}
+
+const AdminCategories = () => {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [name, setName] = useState('');
+
+  const load = async () => {
+    const res = await fetch('/api/categories');
+    setCategories(await res.json());
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const add = async (e: FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/categories', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+    setName('');
+    load();
+  };
+
+  const del = async (id: number) => {
+    await fetch(`/api/categories/${id}`, { method: 'DELETE' });
+    load();
+  };
+
+  return (
+    <div className="p-4">
+      <AdminNav />
+      <h1 className="text-2xl font-bold mb-4">Kategorien</h1>
+      <form onSubmit={add} className="flex gap-2 mb-4">
+        <input
+          className="border p-2"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Name"
+        />
+        <button className="bg-blue-500 text-white p-2">Hinzufügen</button>
+      </form>
+      <ul className="flex flex-col gap-2">
+        {categories.map((cat) => (
+          <li key={cat.id} className="border p-2 flex justify-between">
+            {cat.name}
+            <button onClick={() => del(cat.id)} className="text-red-600">
+              Löschen
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AdminCategories;
+
+export async function getServerSideProps(context: any) {
+  const session = await getSession(context);
+  if (!session || session.user?.role !== 'ADMIN') {
+    return {
+      redirect: {
+        destination: '/admin/login',
+        permanent: false,
+      },
+    };
+  }
+  return { props: {} };
+}

--- a/pages/admin/comments.tsx
+++ b/pages/admin/comments.tsx
@@ -1,0 +1,64 @@
+import { getSession } from 'next-auth/react';
+import { useEffect, useState } from 'react';
+import AdminNav from '../../components/AdminNav';
+
+interface Comment {
+  id: number;
+  name: string;
+  message: string;
+  post: { title: string };
+}
+
+const AdminComments = () => {
+  const [comments, setComments] = useState<Comment[]>([]);
+
+  const load = async () => {
+    const res = await fetch('/api/comments');
+    setComments(await res.json());
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const del = async (id: number) => {
+    await fetch(`/api/comments/${id}`, { method: 'DELETE' });
+    load();
+  };
+
+  return (
+    <div className="p-4">
+      <AdminNav />
+      <h1 className="text-2xl font-bold mb-4">Kommentare</h1>
+      <ul className="flex flex-col gap-2">
+        {comments.map((c) => (
+          <li key={c.id} className="border p-2 flex justify-between">
+            <div>
+              <p className="font-semibold">{c.name}</p>
+              <p className="text-sm">{c.message}</p>
+              <p className="text-xs text-gray-600">Zu: {c.post.title}</p>
+            </div>
+            <button onClick={() => del(c.id)} className="text-red-600">
+              Löschen
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AdminComments;
+
+export async function getServerSideProps(context: any) {
+  const session = await getSession(context);
+  if (!session || session.user?.role !== 'ADMIN') {
+    return {
+      redirect: {
+        destination: '/admin/login',
+        permanent: false,
+      },
+    };
+  }
+  return { props: {} };
+}

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,9 +1,12 @@
 import { getSession } from 'next-auth/react';
+import AdminNav from '../../components/AdminNav';
 
 const AdminHome = () => {
   return (
     <div className="p-4">
+      <AdminNav />
       <h1 className="text-2xl font-bold">Admin Dashboard</h1>
+      <p className="mt-2">Wähle eine Aktion aus der Navigation.</p>
     </div>
   );
 };

--- a/pages/admin/posts.tsx
+++ b/pages/admin/posts.tsx
@@ -1,9 +1,39 @@
 import { getSession } from 'next-auth/react';
+import { useEffect, useState } from 'react';
+import AdminNav from '../../components/AdminNav';
+import PostForm from '../../components/PostForm';
+import PostList from '../../components/PostList';
+
+interface Post {
+  id: number;
+  title: string;
+  category?: { name: string } | null;
+  tags: { id: number; name: string }[];
+}
 
 const AdminPosts = () => {
+  const [posts, setPosts] = useState<Post[]>([]);
+
+  const load = async () => {
+    const res = await fetch('/api/posts');
+    setPosts(await res.json());
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const del = async (id: number) => {
+    await fetch(`/api/posts/${id}`, { method: 'DELETE' });
+    load();
+  };
+
   return (
     <div className="p-4">
-      <h1 className="text-2xl font-bold">Beiträge verwalten</h1>
+      <AdminNav />
+      <h1 className="text-2xl font-bold mb-4">Beiträge verwalten</h1>
+      <PostForm onSuccess={load} />
+      <PostList posts={posts} onDelete={del} />
     </div>
   );
 };

--- a/pages/admin/settings.tsx
+++ b/pages/admin/settings.tsx
@@ -1,0 +1,75 @@
+import { getSession } from 'next-auth/react';
+import { FormEvent, useEffect, useState } from 'react';
+import AdminNav from '../../components/AdminNav';
+
+const AdminSettings = () => {
+  const [siteName, setSiteName] = useState('');
+  const [locale, setLocale] = useState('');
+  const [timezone, setTimezone] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/settings')
+      .then((res) => res.json())
+      .then((data) => {
+        setSiteName(data.siteName || '');
+        setLocale(data.locale || '');
+        setTimezone(data.timezone || '');
+      });
+  }, []);
+
+  const save = async (e: FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/settings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ siteName, locale, timezone }),
+    });
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
+
+  return (
+    <div className="p-4">
+      <AdminNav />
+      <h1 className="text-2xl font-bold mb-4">Einstellungen</h1>
+      <form onSubmit={save} className="flex flex-col gap-2 max-w-md">
+        <input
+          className="border p-2"
+          placeholder="Seitenname"
+          value={siteName}
+          onChange={(e) => setSiteName(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="Locale (z.B. de-DE)"
+          value={locale}
+          onChange={(e) => setLocale(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="Zeitzone (z.B. Europe/Berlin)"
+          value={timezone}
+          onChange={(e) => setTimezone(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white p-2">Speichern</button>
+        {saved && <p className="text-green-600">Gespeichert!</p>}
+      </form>
+    </div>
+  );
+};
+
+export default AdminSettings;
+
+export async function getServerSideProps(context: any) {
+  const session = await getSession(context);
+  if (!session || session.user?.role !== 'ADMIN') {
+    return {
+      redirect: {
+        destination: '/admin/login',
+        permanent: false,
+      },
+    };
+  }
+  return { props: {} };
+}

--- a/pages/admin/tags.tsx
+++ b/pages/admin/tags.tsx
@@ -1,0 +1,79 @@
+import { getSession } from 'next-auth/react';
+import { FormEvent, useEffect, useState } from 'react';
+import AdminNav from '../../components/AdminNav';
+
+interface Tag {
+  id: number;
+  name: string;
+}
+
+const AdminTags = () => {
+  const [tags, setTags] = useState<Tag[]>([]);
+  const [name, setName] = useState('');
+
+  const load = async () => {
+    const res = await fetch('/api/tags');
+    setTags(await res.json());
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const add = async (e: FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/tags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+    setName('');
+    load();
+  };
+
+  const del = async (id: number) => {
+    await fetch(`/api/tags/${id}`, { method: 'DELETE' });
+    load();
+  };
+
+  return (
+    <div className="p-4">
+      <AdminNav />
+      <h1 className="text-2xl font-bold mb-4">Tags</h1>
+      <form onSubmit={add} className="flex gap-2 mb-4">
+        <input
+          className="border p-2"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Name"
+        />
+        <button className="bg-blue-500 text-white p-2">Hinzufügen</button>
+      </form>
+      <ul className="flex flex-col gap-2">
+        {tags.map((tag) => (
+          <li key={tag.id} className="border p-2 flex justify-between">
+            {tag.name}
+            <button onClick={() => del(tag.id)} className="text-red-600">
+              Löschen
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AdminTags;
+
+export async function getServerSideProps(context: any) {
+  const session = await getSession(context);
+  if (!session || session.user?.role !== 'ADMIN') {
+    return {
+      redirect: {
+        destination: '/admin/login',
+        permanent: false,
+      },
+    };
+  }
+  return { props: {} };
+}

--- a/pages/api/categories.ts
+++ b/pages/api/categories.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../lib/prisma';
+import slugify from 'slugify';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const categories = await prisma.category.findMany();
+    return res.json(categories);
+  }
+  if (req.method === 'POST') {
+    const { name } = req.body;
+    const slug = slugify(name, { lower: true });
+    const category = await prisma.category.create({ data: { name, slug } });
+    return res.json(category);
+  }
+  res.status(405).end();
+}

--- a/pages/api/categories/[id].ts
+++ b/pages/api/categories/[id].ts
@@ -1,0 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../../lib/prisma';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const id = Array.isArray(req.query.id) ? req.query.id[0] : req.query.id;
+  if (req.method === 'DELETE') {
+    await prisma.category.delete({ where: { id: Number(id) } });
+    return res.json({ status: 'ok' });
+  }
+  res.status(405).end();
+}

--- a/pages/api/comments.ts
+++ b/pages/api/comments.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../lib/prisma';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const comments = await prisma.comment.findMany({
+      include: { post: { select: { title: true } } },
+      orderBy: { createdAt: 'desc' },
+    });
+    return res.json(comments);
+  }
+  res.status(405).end();
+}

--- a/pages/api/comments/[id].ts
+++ b/pages/api/comments/[id].ts
@@ -1,0 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../../lib/prisma';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const id = Array.isArray(req.query.id) ? req.query.id[0] : req.query.id;
+  if (req.method === 'DELETE') {
+    await prisma.comment.delete({ where: { id: Number(id) } });
+    return res.json({ status: 'ok' });
+  }
+  res.status(405).end();
+}

--- a/pages/api/posts.ts
+++ b/pages/api/posts.ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../lib/prisma';
+import slugify from 'slugify';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const posts = await prisma.post.findMany({
+      include: { category: true, tags: true },
+      orderBy: { createdAt: 'desc' },
+    });
+    return res.json(posts);
+  }
+  if (req.method === 'POST') {
+    const { title, content, categoryId, tagIds } = req.body;
+    const slug = slugify(title, { lower: true });
+    const post = await prisma.post.create({
+      data: {
+        title,
+        content,
+        slug,
+        categoryId: categoryId ? Number(categoryId) : undefined,
+        tags: tagIds && tagIds.length ? { connect: tagIds.map((id: number) => ({ id })) } : undefined,
+      },
+    });
+    return res.json(post);
+  }
+  res.status(405).end();
+}

--- a/pages/api/posts/[id].ts
+++ b/pages/api/posts/[id].ts
@@ -1,0 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../../lib/prisma';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const id = Array.isArray(req.query.id) ? req.query.id[0] : req.query.id;
+  if (req.method === 'DELETE') {
+    await prisma.post.delete({ where: { id: Number(id) } });
+    return res.json({ status: 'ok' });
+  }
+  res.status(405).end();
+}

--- a/pages/api/settings.ts
+++ b/pages/api/settings.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../lib/prisma';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const settings = await prisma.setting.findMany();
+    const data: Record<string, string> = {};
+    settings.forEach((s) => {
+      data[s.key] = s.value;
+    });
+    return res.json(data);
+  }
+  if (req.method === 'POST') {
+    const entries = req.body as Record<string, string>;
+    for (const [key, value] of Object.entries(entries)) {
+      await prisma.setting.upsert({
+        where: { key },
+        update: { value: String(value) },
+        create: { key, value: String(value) },
+      });
+    }
+    return res.json({ status: 'ok' });
+  }
+  res.status(405).end();
+}

--- a/pages/api/tags.ts
+++ b/pages/api/tags.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../lib/prisma';
+import slugify from 'slugify';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const tags = await prisma.tag.findMany();
+    return res.json(tags);
+  }
+  if (req.method === 'POST') {
+    const { name } = req.body;
+    const slug = slugify(name, { lower: true });
+    const tag = await prisma.tag.create({ data: { name, slug } });
+    return res.json(tag);
+  }
+  res.status(405).end();
+}

--- a/pages/api/tags/[id].ts
+++ b/pages/api/tags/[id].ts
@@ -1,0 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../../lib/prisma';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const id = Array.isArray(req.query.id) ? req.query.id[0] : req.query.id;
+  if (req.method === 'DELETE') {
+    await prisma.tag.delete({ where: { id: Number(id) } });
+    return res.json({ status: 'ok' });
+  }
+  res.status(405).end();
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,3 +59,9 @@ model Comment {
   user      User?    @relation(fields: [userId], references: [id])
   userId    Int?
 }
+
+model Setting {
+  id    Int    @id @default(autoincrement())
+  key   String @unique
+  value String
+}


### PR DESCRIPTION
## Summary
- expand Prisma schema with Setting model for configurable site options
- add API routes and admin pages for posts, categories, tags, comments, and settings management
- include navigation component for streamlined backend moderation

## Testing
- `npx prisma generate`
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c469b153108333a1813a2f8626fbeb