### PR TITLE
Connect backend posts to frontend

### DIFF
--- a/components/CommentSection.tsx
+++ b/components/CommentSection.tsx
@@ -1,5 +1,73 @@
-const CommentSection = () => {
-  return <div>Comment Section Placeholder</div>;
+import { FormEvent, useEffect, useState } from 'react';
+
+interface Comment {
+  id: number;
+  name: string;
+  message: string;
+  createdAt: string;
+}
+
+const CommentSection = ({ postId }: { postId: number }) => {
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [name, setName] = useState('');
+  const [message, setMessage] = useState('');
+
+  const loadComments = async () => {
+    const res = await fetch(`/api/comments?postId=${postId}`);
+    const data = await res.json();
+    setComments(data);
+  };
+
+  useEffect(() => {
+    loadComments();
+  }, [postId]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/comments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ postId, name, message }),
+    });
+    setName('');
+    setMessage('');
+    loadComments();
+  };
+
+  return (
+    <div id="comments" className="mt-8">
+      <h3 className="text-lg font-semibold mb-2">Kommentare</h3>
+      {comments.length ? (
+        <ul className="mb-4">
+          {comments.map((c) => (
+            <li key={c.id} className="mb-2">
+              <p className="text-sm font-semibold">{c.name}</p>
+              <p className="text-sm">{c.message}</p>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mb-4 text-sm">Keine Kommentare vorhanden.</p>
+      )}
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <input
+          className="border p-2"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <textarea
+          className="border p-2"
+          placeholder="Kommentar"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+        />
+        <button type="submit" className="bg-blue-500 text-white p-2">
+          Abschicken
+        </button>
+      </form>
+    </div>
+  );
 };
 
 export default CommentSection;

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -3,7 +3,7 @@ import CredentialsProvider from 'next-auth/providers/credentials';
 import { prisma } from '../../../lib/prisma';
 import bcrypt from 'bcryptjs';
 
-export default NextAuth({
+export const authOptions = {
   session: {
     strategy: 'jwt',
   },
@@ -42,4 +42,6 @@ export default NextAuth({
       return session;
     },
   },
-});
+};
+
+export default NextAuth(authOptions);

--- a/pages/api/comments.ts
+++ b/pages/api/comments.ts
@@ -3,11 +3,23 @@ import { prisma } from '../../lib/prisma';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
+    const { postId } = req.query;
+    const where = postId ? { postId: Number(postId) } : {};
     const comments = await prisma.comment.findMany({
-      include: { post: { select: { title: true } } },
+      where,
       orderBy: { createdAt: 'desc' },
     });
     return res.json(comments);
+  }
+  if (req.method === 'POST') {
+    const { postId, name, message } = req.body;
+    if (!postId || !name || !message) {
+      return res.status(400).json({ error: 'Missing fields' });
+    }
+    const comment = await prisma.comment.create({
+      data: { postId: Number(postId), name, message },
+    });
+    return res.json(comment);
   }
   res.status(405).end();
 }

--- a/pages/api/posts.ts
+++ b/pages/api/posts.ts
@@ -1,16 +1,24 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { prisma } from '../../lib/prisma';
 import slugify from 'slugify';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from './auth/[...nextauth]';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
     const posts = await prisma.post.findMany({
-      include: { category: true, tags: true },
+      include: {
+        category: true,
+        tags: true,
+        author: { select: { username: true } },
+      },
       orderBy: { createdAt: 'desc' },
     });
     return res.json(posts);
   }
   if (req.method === 'POST') {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session) return res.status(401).json({ error: 'Unauthorized' });
     const { title, content, categoryId, tagIds } = req.body;
     const slug = slugify(title, { lower: true });
     const post = await prisma.post.create({
@@ -19,7 +27,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         content,
         slug,
         categoryId: categoryId ? Number(categoryId) : undefined,
-        tags: tagIds && tagIds.length ? { connect: tagIds.map((id: number) => ({ id })) } : undefined,
+        authorId: Number((session.user as any).id),
+        tags:
+          tagIds && tagIds.length
+            ? { connect: tagIds.map((id: number) => ({ id })) }
+            : undefined,
+      },
+      include: {
+        category: true,
+        tags: true,
+        author: { select: { username: true } },
       },
     });
     return res.json(post);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,12 +1,60 @@
-import type { NextPage } from 'next';
+import { GetServerSideProps, NextPage } from 'next';
+import Link from 'next/link';
+import { prisma } from '../lib/prisma';
 
-const Home: NextPage = () => {
+interface Post {
+  id: number;
+  title: string;
+  slug: string;
+  createdAt: string;
+  author?: { username: string } | null;
+  category?: { name: string } | null;
+  tags: { id: number; name: string }[];
+}
+
+interface HomeProps {
+  posts: Post[];
+}
+
+const Home: NextPage<HomeProps> = ({ posts }) => {
   return (
     <div className="p-4">
-      <h1 className="text-2xl font-bold">NewsBlogCMS</h1>
-      <p>Willkommen zu deinem neuen News-Blog.</p>
+      <h1 className="text-2xl font-bold mb-4">NewsBlogCMS</h1>
+      {posts.map((post) => (
+        <div key={post.id} className="mb-6 border-b pb-4">
+          <h2 className="text-xl font-semibold">
+            <Link href={`/news/${post.slug}`}>{post.title}</Link>
+          </h2>
+          <p className="text-sm text-gray-500">
+            {new Date(post.createdAt).toLocaleDateString()} | Autor: {post.author?.username || 'Unbekannt'} |
+            Kategorie: {post.category?.name || 'Keine'}
+          </p>
+          {post.tags.length > 0 && (
+            <p className="text-sm">Tags: {post.tags.map((t) => t.name).join(', ')}</p>
+          )}
+          <Link href={`/news/${post.slug}#comments`} className="text-blue-600 text-sm">
+            Kommentare ansehen
+          </Link>
+        </div>
+      ))}
     </div>
   );
+};
+
+export const getServerSideProps: GetServerSideProps<HomeProps> = async () => {
+  const posts = await prisma.post.findMany({
+    include: {
+      author: { select: { username: true } },
+      category: true,
+      tags: true,
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+  return {
+    props: {
+      posts: posts.map((p) => ({ ...p, createdAt: p.createdAt.toISOString() })),
+    },
+  };
 };
 
 export default Home;

--- a/pages/news/[slug].tsx
+++ b/pages/news/[slug].tsx
@@ -1,12 +1,52 @@
-import { useRouter } from 'next/router';
+import { GetServerSideProps } from 'next';
+import Link from 'next/link';
+import { prisma } from '../../lib/prisma';
+import CommentSection from '../../components/CommentSection';
 
-const NewsPost = () => {
-  const { slug } = useRouter().query;
+interface PostPageProps {
+  post: {
+    id: number;
+    title: string;
+    content: string;
+    slug: string;
+    createdAt: string;
+    author?: { username: string } | null;
+    category?: { name: string } | null;
+    tags: { id: number; name: string }[];
+  } | null;
+}
+
+const NewsPost = ({ post }: PostPageProps) => {
+  if (!post) return <div className="p-4">Beitrag nicht gefunden.</div>;
   return (
     <div className="p-4">
-      <h1 className="text-2xl font-bold">Beitrag: {slug}</h1>
+      <h1 className="text-2xl font-bold mb-2">{post.title}</h1>
+      <p className="text-sm text-gray-500 mb-4">
+        {new Date(post.createdAt).toLocaleDateString()} | Autor: {post.author?.username || 'Unbekannt'} | Kategorie: {post.category?.name || 'Keine'}
+      </p>
+      {post.tags.length > 0 && (
+        <p className="text-sm mb-4">Tags: {post.tags.map((t) => t.name).join(', ')}</p>
+      )}
+      <div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: post.content }} />
+      <CommentSection postId={post.id} />
+      <Link href="/" className="text-blue-600">
+        Zurück zur Startseite
+      </Link>
     </div>
   );
+};
+
+export const getServerSideProps: GetServerSideProps<PostPageProps> = async (context) => {
+  const slug = context.params?.slug as string;
+  const post = await prisma.post.findUnique({
+    where: { slug },
+    include: {
+      author: { select: { username: true } },
+      category: true,
+      tags: true,
+    },
+  });
+  return { props: { post: post ? { ...post, createdAt: post.createdAt.toISOString() } : null } };
 };
 
 export default NewsPost;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
   role     Role     @default(USER)
   name     String?
   comments Comment[]
+  posts    Post[]
 }
 
 model Post {
@@ -31,6 +32,8 @@ model Post {
   updatedAt  DateTime  @updatedAt
   category   Category? @relation(fields: [categoryId], references: [id])
   categoryId Int?
+  author     User?     @relation(fields: [authorId], references: [id])
+  authorId   Int?
   tags       Tag[]     @relation("PostTags")
   comments   Comment[]
 }


### PR DESCRIPTION
## Summary
- add author relation to posts and expose NextAuth options
- expand post and comment APIs and implement frontend comment section
- list posts on homepage with metadata and link to comments

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c46bb260fc8333b1cb7eab46992dab