### PR TITLE
Fix date serialization for posts

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,6 +7,7 @@ interface Post {
   title: string;
   slug: string;
   createdAt: string;
+  updatedAt: string;
   author?: { username: string } | null;
   category?: { name: string } | null;
   tags: { id: number; name: string }[];
@@ -52,7 +53,11 @@ export const getServerSideProps: GetServerSideProps<HomeProps> = async () => {
   });
   return {
     props: {
-      posts: posts.map((p) => ({ ...p, createdAt: p.createdAt.toISOString() })),
+      posts: posts.map((p) => ({
+        ...p,
+        createdAt: p.createdAt.toISOString(),
+        updatedAt: p.updatedAt.toISOString(),
+      })),
     },
   };
 };

--- a/pages/news/[slug].tsx
+++ b/pages/news/[slug].tsx
@@ -10,6 +10,7 @@ interface PostPageProps {
     content: string;
     slug: string;
     createdAt: string;
+    updatedAt: string;
     author?: { username: string } | null;
     category?: { name: string } | null;
     tags: { id: number; name: string }[];
@@ -46,7 +47,17 @@ export const getServerSideProps: GetServerSideProps<PostPageProps> = async (cont
       tags: true,
     },
   });
-  return { props: { post: post ? { ...post, createdAt: post.createdAt.toISOString() } : null } };
+  return {
+    props: {
+      post: post
+        ? {
+            ...post,
+            createdAt: post.createdAt.toISOString(),
+            updatedAt: post.updatedAt.toISOString(),
+          }
+        : null,
+    },
+  };
 };
 
 export default NewsPost;


### PR DESCRIPTION
## Summary
- serialize `createdAt` and `updatedAt` values for posts on index and detail pages to avoid Next.js SSR errors

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68c473fc6770833394e0302e4bfbca72