### PR TITLE
Include post titles when listing comments

### DIFF
--- a/pages/api/comments.ts
+++ b/pages/api/comments.ts
@@ -7,6 +7,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const where = postId ? { postId: Number(postId) } : {};
     const comments = await prisma.comment.findMany({
       where,
+      include: { post: { select: { title: true } } },
       orderBy: { createdAt: 'desc' },
     });
     return res.json(comments);


### PR DESCRIPTION
## Summary
- include associated post titles in the comments API so admin comments page can display them

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68c4761ea1d08333af4ebb09e6508788