### PR TITLE
Sync site title with settings

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,12 +1,15 @@
 import Link from 'next/link';
 import { signOut, useSession } from 'next-auth/react';
+import { useContext } from 'react';
+import { SiteContext } from '../lib/SiteContext';
 
 const NavBar = () => {
   const { data: session } = useSession();
+  const { siteName } = useContext(SiteContext);
 
   return (
     <nav className="flex gap-4 p-4 border-b">
-      <Link href="/">Startseite</Link>
+      <Link href="/">{siteName}</Link>
       {session ? (
         <>
           <Link href="/profile">Profil</Link>

--- a/lib/SiteContext.tsx
+++ b/lib/SiteContext.tsx
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+
+export interface SiteContextValue {
+  siteName: string;
+}
+
+export const SiteContext = createContext<SiteContextValue>({ siteName: 'NewsBlogCMS' });
+

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,13 +1,30 @@
 import type { AppProps } from 'next/app';
 import { SessionProvider } from 'next-auth/react';
+import { useEffect, useState } from 'react';
+import Head from 'next/head';
 import '../styles/globals.css';
 import NavBar from '../components/NavBar';
+import { SiteContext } from '../lib/SiteContext';
 
 export default function MyApp({ Component, pageProps: { session, ...pageProps } }: AppProps) {
+  const [siteName, setSiteName] = useState('NewsBlogCMS');
+
+  useEffect(() => {
+    fetch('/api/settings')
+      .then((res) => res.json())
+      .then((data) => setSiteName(data.siteName || 'NewsBlogCMS'))
+      .catch(() => {});
+  }, []);
+
   return (
     <SessionProvider session={session}>
-      <NavBar />
-      <Component {...pageProps} />
+      <SiteContext.Provider value={{ siteName }}>
+        <Head>
+          <title>{siteName}</title>
+        </Head>
+        <NavBar />
+        <Component {...pageProps} />
+      </SiteContext.Provider>
     </SessionProvider>
   );
 }

--- a/pages/admin/settings.tsx
+++ b/pages/admin/settings.tsx
@@ -36,7 +36,7 @@ const AdminSettings = () => {
       <form onSubmit={save} className="flex flex-col gap-2 max-w-md">
         <input
           className="border p-2"
-          placeholder="Seitenname"
+          placeholder="Seitentitel"
           value={siteName}
           onChange={(e) => setSiteName(e.target.value)}
         />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,8 @@
 import { GetServerSideProps, NextPage } from 'next';
 import Link from 'next/link';
+import { useContext } from 'react';
 import { prisma } from '../lib/prisma';
+import { SiteContext } from '../lib/SiteContext';
 
 interface Post {
   id: number;
@@ -18,9 +20,10 @@ interface HomeProps {
 }
 
 const Home: NextPage<HomeProps> = ({ posts }) => {
+  const { siteName } = useContext(SiteContext);
   return (
     <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">NewsBlogCMS</h1>
+      <h1 className="text-2xl font-bold mb-4">{siteName}</h1>
       {posts.map((post) => (
         <div key={post.id} className="mb-6 border-b pb-4">
           <h2 className="text-xl font-semibold">


### PR DESCRIPTION
## Summary
- load site title from settings in a global context and <Head>
- show dynamic site title in nav bar and home page
- rename admin setting placeholder to "Seitentitel"

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68c4779946bc8333853d3d494af79567