### PR TITLE
Prevent site title setting from replacing Startseite link

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -9,7 +9,8 @@ const NavBar = () => {
 
   return (
     <nav className="flex gap-4 p-4 border-b">
-      <Link href="/">{siteName}</Link>
+      <span className="font-bold">{siteName}</span>
+      <Link href="/">Startseite</Link>
       {session ? (
         <>
           <Link href="/profile">Profil</Link>


### PR DESCRIPTION
## Summary
- Display configured site title in the header without altering the "Startseite" navigation link

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c4795514788333be2991ecfdbed1f8