### PR TITLE
Add light and dark mode toggle

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -8,18 +8,20 @@ const NavBar = () => {
   const { siteName } = useContext(SiteContext);
 
   return (
-    <nav className="flex gap-4 p-4 border-b">
-      <span className="font-bold">{siteName}</span>
-      <Link href="/">Startseite</Link>
-      {session ? (
-        <>
-          <Link href="/profile">Profil</Link>
-          {session.user?.role === 'ADMIN' && <Link href="/admin">Backend</Link>}
-          <button onClick={() => signOut()} className="text-blue-600">Logout</button>
-        </>
-      ) : (
-        <Link href="/admin/login">Login</Link>
-      )}
+    <nav className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
+      <span className="font-bold text-xl">{siteName}</span>
+      <div className="flex gap-4">
+        <Link href="/">Startseite</Link>
+        {session ? (
+          <>
+            <Link href="/profile">Profil</Link>
+            {session.user?.role === 'ADMIN' && <Link href="/admin">Backend</Link>}
+            <button onClick={() => signOut()} className="text-blue-600 dark:text-blue-400">Logout</button>
+          </>
+        ) : (
+          <Link href="/admin/login" className="text-blue-600 dark:text-blue-400">Login</Link>
+        )}
+      </div>
     </nav>
   );
 };

--- a/lib/ThemeContext.tsx
+++ b/lib/ThemeContext.tsx
@@ -1,0 +1,14 @@
+import { createContext } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+export interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+export const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,9 +5,11 @@ import Head from 'next/head';
 import '../styles/globals.css';
 import NavBar from '../components/NavBar';
 import { SiteContext } from '../lib/SiteContext';
+import { ThemeContext, Theme } from '../lib/ThemeContext';
 
 export default function MyApp({ Component, pageProps: { session, ...pageProps } }: AppProps) {
   const [siteName, setSiteName] = useState('NewsBlogCMS');
+  const [theme, setTheme] = useState<Theme>('light');
 
   useEffect(() => {
     fetch('/api/settings')
@@ -16,14 +18,39 @@ export default function MyApp({ Component, pageProps: { session, ...pageProps } 
       .catch(() => {});
   }, []);
 
+  useEffect(() => {
+    const stored = (typeof window !== 'undefined' && window.localStorage.getItem('theme')) as Theme | null;
+    if (stored) {
+      setTheme(stored);
+      if (stored === 'dark') {
+        document.documentElement.classList.add('dark');
+      }
+    }
+  }, []);
+
+  const toggleTheme = () => {
+    const newTheme = theme === 'light' ? 'dark' : 'light';
+    setTheme(newTheme);
+    if (newTheme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('theme', newTheme);
+    }
+  };
+
   return (
     <SessionProvider session={session}>
       <SiteContext.Provider value={{ siteName }}>
-        <Head>
-          <title>{siteName}</title>
-        </Head>
-        <NavBar />
-        <Component {...pageProps} />
+        <ThemeContext.Provider value={{ theme, toggleTheme }}>
+          <Head>
+            <title>{siteName}</title>
+          </Head>
+          <NavBar />
+          <Component {...pageProps} />
+        </ThemeContext.Provider>
       </SiteContext.Provider>
     </SessionProvider>
   );

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,11 +1,24 @@
 import { getSession, useSession } from 'next-auth/react';
+import { useContext } from 'react';
+import { ThemeContext } from '../lib/ThemeContext';
 
 const Profile = () => {
   const { data: session } = useSession();
+  const { theme, toggleTheme } = useContext(ThemeContext);
+
   return (
-    <div className="p-4">
+    <div className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Profil</h1>
       {session && <p>Angemeldet als {session.user?.name}</p>}
+      <div>
+        <span className="mr-2">Modus:</span>
+        <button
+          onClick={toggleTheme}
+          className="px-3 py-1 border rounded bg-gray-100 dark:bg-gray-800 dark:border-gray-700"
+        >
+          {theme === 'light' ? 'Dark Mode' : 'Light Mode'}
+        </button>
+      </div>
     </div>
   );
 };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,12 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply bg-white text-gray-900;
+  }
+  .dark body {
+    @apply bg-gray-900 text-gray-100;
+  }
+}


### PR DESCRIPTION
## Summary
- add ThemeContext and theme persistence
- provide mode switch in profile page and restyle navigation
- configure ESLint for linting

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4807157d483338f1877bc3d711d30