### PR TITLE
feat: add maintenance mode with update endpoint

### DIFF
--- a/components/Maintenance.tsx
+++ b/components/Maintenance.tsx
@@ -1,0 +1,33 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+interface Props {
+  currentPath: string;
+}
+
+const Maintenance = ({ currentPath }: Props) => {
+  const router = useRouter();
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      try {
+        const res = await fetch('/api/settings');
+        const data = await res.json();
+        if (data.maintenance !== 'true') {
+          clearInterval(interval);
+          router.replace(currentPath);
+        }
+      } catch (e) {
+        // ignore
+      }
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [currentPath, router]);
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <h1 className="text-2xl">Be right back...</h1>
+    </div>
+  );
+};
+
+export default Maintenance;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,20 +1,27 @@
 import type { AppProps } from 'next/app';
 import { SessionProvider } from 'next-auth/react';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 import Head from 'next/head';
 import '../styles/globals.css';
 import NavBar from '../components/NavBar';
 import { SiteContext } from '../lib/SiteContext';
 import { ThemeContext, Theme } from '../lib/ThemeContext';
+import Maintenance from '../components/Maintenance';
 
 export default function MyApp({ Component, pageProps: { session, ...pageProps } }: AppProps) {
+  const router = useRouter();
   const [siteName, setSiteName] = useState('NewsBlogCMS');
   const [theme, setTheme] = useState<Theme>('light');
+  const [maintenance, setMaintenance] = useState(false);
 
   useEffect(() => {
     fetch('/api/settings')
       .then((res) => res.json())
-      .then((data) => setSiteName(data.siteName || 'NewsBlogCMS'))
+      .then((data) => {
+        setSiteName(data.siteName || 'NewsBlogCMS');
+        setMaintenance(data.maintenance === 'true');
+      })
       .catch(() => {});
   }, []);
 
@@ -40,6 +47,10 @@ export default function MyApp({ Component, pageProps: { session, ...pageProps } 
       window.localStorage.setItem('theme', newTheme);
     }
   };
+
+  if (maintenance) {
+    return <Maintenance currentPath={router.asPath} />;
+  }
 
   return (
     <SessionProvider session={session}>

--- a/pages/admin/settings.tsx
+++ b/pages/admin/settings.tsx
@@ -7,6 +7,7 @@ const AdminSettings = () => {
   const [locale, setLocale] = useState('');
   const [timezone, setTimezone] = useState('');
   const [saved, setSaved] = useState(false);
+  const [updating, setUpdating] = useState(false);
 
   useEffect(() => {
     fetch('/api/settings')
@@ -54,6 +55,18 @@ const AdminSettings = () => {
         />
         <button className="bg-blue-500 text-white p-2">Speichern</button>
         {saved && <p className="text-green-600">Gespeichert!</p>}
+        <button
+          type="button"
+          onClick={async () => {
+            setUpdating(true);
+            await fetch('/api/update', { method: 'POST' });
+            setUpdating(false);
+          }}
+          className="bg-gray-500 text-white p-2"
+        >
+          Update
+        </button>
+        {updating && <p className="text-blue-600">Aktualisiere...</p>}
       </form>
     </div>
   );

--- a/pages/api/update.ts
+++ b/pages/api/update.ts
@@ -1,0 +1,48 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { exec } from 'child_process';
+import { prisma } from '../../lib/prisma';
+import { getServerSession } from 'next-auth';
+import { authOptions } from './auth/[...nextauth]';
+
+function run(cmd: string) {
+  return new Promise<void>((resolve, reject) => {
+    exec(cmd, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session || (session.user as any).role !== 'ADMIN') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  if (req.method !== 'POST') {
+    return res.status(405).end();
+  }
+
+  await prisma.setting.upsert({
+    where: { key: 'maintenance' },
+    update: { value: 'true' },
+    create: { key: 'maintenance', value: 'true' },
+  });
+
+  try {
+    await run('git pull');
+    await run('npx prisma migrate deploy');
+    await prisma.setting.upsert({
+      where: { key: 'maintenance' },
+      update: { value: 'false' },
+      create: { key: 'maintenance', value: 'false' },
+    });
+    res.json({ status: 'updated' });
+  } catch (e) {
+    await prisma.setting.upsert({
+      where: { key: 'maintenance' },
+      update: { value: 'false' },
+      create: { key: 'maintenance', value: 'false' },
+    });
+    res.status(500).json({ error: 'Update failed' });
+  }
+}


### PR DESCRIPTION
## Summary
- add maintenance page polling settings to restore previous view
- introduce update API that sets maintenance mode, pulls code and migrates DB
- expose update button in admin settings

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c48437ea30833390453176a22c9167