### PR TITLE
feat: add user roles and profile management

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 NewsBlogCMS ist ein moderner News-Blog mit Next.js, Tailwind CSS, Prisma und PostgreSQL. Über eine Adminoberfläche lassen sich Beiträge, Kategorien, Tags und Kommentare verwalten.
 
+## Benutzerrollen
+
+Das System unterstützt mehrere Rollen:
+
+- **Gast** – kann lesen und Kommentare verfassen (Moderationsfreigabe erforderlich)
+- **User** – kann lesen und Kommentare ohne Freigabe schreiben
+- **Autor** – kann zusätzlich Artikel verfassen
+- **Moderator** – kann Kommentare freigeben, ablehnen oder löschen
+- **Admin** – volle Rechte
+
+Anmeldungen können im Backend deaktiviert oder aktiviert werden.
+
 ## Installation
 
 Führe das Setup-Skript aus, um Abhängigkeiten zu installieren, die `.env`-Datei anzulegen, PostgreSQL einzurichten und die Datenbank zu migrieren sowie mit Beispieldaten zu füllen:

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { signOut, useSession } from 'next-auth/react';
-import { useContext } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { SiteContext } from '../lib/SiteContext';
 import { ThemeContext } from '../lib/ThemeContext';
 
@@ -8,6 +8,13 @@ const NavBar = () => {
   const { data: session } = useSession();
   const { siteName } = useContext(SiteContext);
   const { theme, toggleTheme } = useContext(ThemeContext);
+  const [allowSignup, setAllowSignup] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/settings')
+      .then((res) => res.json())
+      .then((data) => setAllowSignup(data.allowSignup === 'true'));
+  }, []);
 
   return (
     <nav className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
@@ -21,7 +28,14 @@ const NavBar = () => {
             <button onClick={() => signOut()} className="text-blue-600 dark:text-blue-400">Logout</button>
           </>
         ) : (
-          <Link href="/admin/login" className="text-blue-600 dark:text-blue-400">Login</Link>
+          <>
+            <Link href="/admin/login" className="text-blue-600 dark:text-blue-400">Login</Link>
+            {allowSignup && (
+              <Link href="/signup" className="text-blue-600 dark:text-blue-400">
+                Signup
+              </Link>
+            )}
+          </>
         )}
         <button
           onClick={toggleTheme}

--- a/pages/admin/login.tsx
+++ b/pages/admin/login.tsx
@@ -1,11 +1,19 @@
-import { FormEvent, useState } from 'react';
+import { FormEvent, useEffect, useState } from 'react';
 import { signIn, getSession } from 'next-auth/react';
 import { useRouter } from 'next/router';
+import Link from 'next/link';
 
 const AdminLogin = () => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const [allowSignup, setAllowSignup] = useState(false);
   const router = useRouter();
+
+  useEffect(() => {
+    fetch('/api/settings')
+      .then((res) => res.json())
+      .then((data) => setAllowSignup(data.allowSignup === 'true'));
+  }, []);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -41,6 +49,14 @@ const AdminLogin = () => {
           Login
         </button>
       </form>
+      {allowSignup && (
+        <p className="mt-4 text-sm">
+          Noch kein Account?{' '}
+          <Link href="/signup" className="text-blue-600 underline">
+            Signup
+          </Link>
+        </p>
+      )}
     </div>
   );
 };

--- a/pages/admin/posts.tsx
+++ b/pages/admin/posts.tsx
@@ -42,7 +42,10 @@ export default AdminPosts;
 
 export async function getServerSideProps(context: any) {
   const session = await getSession(context);
-  if (!session || session.user?.role !== 'ADMIN') {
+  if (
+    !session ||
+    !['ADMIN', 'AUTHOR'].includes((session.user as any).role)
+  ) {
     return {
       redirect: {
         destination: '/admin/login',

--- a/pages/admin/settings.tsx
+++ b/pages/admin/settings.tsx
@@ -6,6 +6,7 @@ const AdminSettings = () => {
   const [siteName, setSiteName] = useState('');
   const [locale, setLocale] = useState('');
   const [timezone, setTimezone] = useState('');
+  const [allowSignup, setAllowSignup] = useState(false);
   const [saved, setSaved] = useState(false);
   const [updating, setUpdating] = useState(false);
 
@@ -16,6 +17,7 @@ const AdminSettings = () => {
         setSiteName(data.siteName || '');
         setLocale(data.locale || '');
         setTimezone(data.timezone || '');
+        setAllowSignup(data.allowSignup === 'true');
       });
   }, []);
 
@@ -24,7 +26,7 @@ const AdminSettings = () => {
     await fetch('/api/settings', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ siteName, locale, timezone }),
+      body: JSON.stringify({ siteName, locale, timezone, allowSignup }),
     });
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
@@ -53,6 +55,14 @@ const AdminSettings = () => {
           value={timezone}
           onChange={(e) => setTimezone(e.target.value)}
         />
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={allowSignup}
+            onChange={(e) => setAllowSignup(e.target.checked)}
+          />
+          <span>Signup erlauben</span>
+        </label>
         <button className="bg-blue-500 text-white p-2">Speichern</button>
         {saved && <p className="text-green-600">Gespeichert!</p>}
         <button

--- a/pages/api/comments.ts
+++ b/pages/api/comments.ts
@@ -1,10 +1,16 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { prisma } from '../../lib/prisma';
+import { getServerSession } from 'next-auth';
+import { authOptions } from './auth/[...nextauth]';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession(req, res, authOptions);
   if (req.method === 'GET') {
     const { postId } = req.query;
-    const where = postId ? { postId: Number(postId) } : {};
+    const where: any = postId ? { postId: Number(postId) } : {};
+    if (!session || !['MODERATOR', 'ADMIN'].includes((session.user as any).role)) {
+      where.status = 'APPROVED';
+    }
     const comments = await prisma.comment.findMany({
       where,
       include: { post: { select: { title: true } } },
@@ -14,11 +20,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
   if (req.method === 'POST') {
     const { postId, name, message } = req.body;
-    if (!postId || !name || !message) {
+    if (!postId || !message) {
       return res.status(400).json({ error: 'Missing fields' });
     }
+    const approved = session && (session.user as any).role !== 'GUEST';
+    if (!approved && !name) {
+      return res.status(400).json({ error: 'Missing name' });
+    }
     const comment = await prisma.comment.create({
-      data: { postId: Number(postId), name, message },
+      data: {
+        postId: Number(postId),
+        name: session?.user?.name || name,
+        message,
+        status: approved ? 'APPROVED' : 'PENDING',
+        userId: session ? Number((session.user as any).id) : undefined,
+      },
     });
     return res.json(comment);
   }

--- a/pages/api/comments/[id].ts
+++ b/pages/api/comments/[id].ts
@@ -1,10 +1,21 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { prisma } from '../../../lib/prisma';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../auth/[...nextauth]';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const id = Array.isArray(req.query.id) ? req.query.id[0] : req.query.id;
+  const session = await getServerSession(req, res, authOptions);
+  if (!session || !['MODERATOR', 'ADMIN'].includes((session.user as any).role)) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
   if (req.method === 'DELETE') {
     await prisma.comment.delete({ where: { id: Number(id) } });
+    return res.json({ status: 'ok' });
+  }
+  if (req.method === 'PATCH') {
+    const { status } = req.body;
+    await prisma.comment.update({ where: { id: Number(id) }, data: { status } });
     return res.json({ status: 'ok' });
   }
   res.status(405).end();

--- a/pages/api/profile.ts
+++ b/pages/api/profile.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth';
+import { authOptions } from './auth/[...nextauth]';
+import { prisma } from '../../lib/prisma';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: 'Not authenticated' });
+  }
+  const userId = Number((session.user as any).id);
+
+  if (req.method === 'GET') {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { name: true, bio: true, image: true },
+    });
+    return res.json(user);
+  }
+  if (req.method === 'POST') {
+    const { name, bio, image } = req.body;
+    await prisma.user.update({
+      where: { id: userId },
+      data: { name, bio, image },
+    });
+    return res.json({ status: 'ok' });
+  }
+  res.status(405).end();
+}

--- a/pages/api/signup.ts
+++ b/pages/api/signup.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../lib/prisma';
+import bcrypt from 'bcryptjs';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).end();
+  }
+
+  const setting = await prisma.setting.findUnique({ where: { key: 'allowSignup' } });
+  if (setting && setting.value !== 'true') {
+    return res.status(403).json({ error: 'Signup disabled' });
+  }
+
+  const { username, email, password } = req.body;
+  if (!username || !email || !password) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+
+  const existing = await prisma.user.findFirst({
+    where: { OR: [{ username }, { email }] },
+  });
+  if (existing) {
+    return res.status(400).json({ error: 'User exists' });
+  }
+
+  const hashed = await bcrypt.hash(password, 10);
+  const user = await prisma.user.create({
+    data: { username, email, password: hashed, role: 'USER' },
+  });
+
+  res.json({ id: user.id });
+}

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,15 +1,61 @@
 import { getSession, useSession } from 'next-auth/react';
-import { useContext } from 'react';
+import { useContext, useEffect, useState, FormEvent } from 'react';
 import { ThemeContext } from '../lib/ThemeContext';
 
 const Profile = () => {
   const { data: session } = useSession();
   const { theme, toggleTheme } = useContext(ThemeContext);
+  const [name, setName] = useState('');
+  const [bio, setBio] = useState('');
+  const [image, setImage] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/profile')
+      .then((res) => res.json())
+      .then((data) => {
+        setName(data?.name || '');
+        setBio(data?.bio || '');
+        setImage(data?.image || '');
+      });
+  }, []);
+
+  const save = async (e: FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/profile', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, bio, image }),
+    });
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
 
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Profil</h1>
-      {session && <p>Angemeldet als {session.user?.name}</p>}
+      <form onSubmit={save} className="flex flex-col gap-2 max-w-sm">
+        <input
+          className="border p-2"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <textarea
+          className="border p-2"
+          placeholder="Bio"
+          value={bio}
+          onChange={(e) => setBio(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="Bild-URL"
+          value={image}
+          onChange={(e) => setImage(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white p-2">Speichern</button>
+        {saved && <p className="text-green-600">Gespeichert!</p>}
+      </form>
       <div>
         <span className="mr-2">Modus:</span>
         <button

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -1,0 +1,79 @@
+import { FormEvent, useState } from 'react';
+import { getSession } from 'next-auth/react';
+import { useRouter } from 'next/router';
+
+const Signup = ({ allowSignup }: { allowSignup: boolean }) => {
+  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const router = useRouter();
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, email, password }),
+    });
+    if (res.ok) {
+      router.push('/admin/login');
+    } else {
+      const data = await res.json();
+      setError(data.error || 'Fehler');
+    }
+  };
+
+  if (!allowSignup) {
+    return <p className="p-4">Registrierung deaktiviert.</p>;
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Signup</h1>
+      <form onSubmit={submit} className="flex flex-col gap-2 max-w-sm">
+        <input
+          className="border p-2"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="Email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="Passwort"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white p-2" type="submit">
+          Registrieren
+        </button>
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+      </form>
+    </div>
+  );
+};
+
+export default Signup;
+
+export async function getServerSideProps(ctx: any) {
+  const session = await getSession(ctx);
+  if (session) {
+    return {
+      redirect: {
+        destination: '/',
+        permanent: false,
+      },
+    };
+  }
+  const { prisma } = await import('../lib/prisma');
+  const setting = await prisma.setting.findUnique({ where: { key: 'allowSignup' } });
+  return { props: { allowSignup: setting?.value === 'true' } };
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,7 +8,10 @@ datasource db {
 }
 
 enum Role {
+  GUEST
   USER
+  AUTHOR
+  MODERATOR
   ADMIN
 }
 
@@ -19,6 +22,8 @@ model User {
   password String
   role     Role     @default(USER)
   name     String?
+  bio      String?
+  image    String?
   comments Comment[]
   posts    Post[]
 }
@@ -52,14 +57,21 @@ model Tag {
   posts Post[] @relation("PostTags")
 }
 
+enum CommentStatus {
+  PENDING
+  APPROVED
+  REJECTED
+}
+
 model Comment {
-  id        Int      @id @default(autoincrement())
+  id        Int            @id @default(autoincrement())
   name      String
   message   String
-  createdAt DateTime @default(now())
-  post      Post     @relation(fields: [postId], references: [id])
+  createdAt DateTime       @default(now())
+  status    CommentStatus  @default(PENDING)
+  post      Post           @relation(fields: [postId], references: [id])
   postId    Int
-  user      User?    @relation(fields: [userId], references: [id])
+  user      User?          @relation(fields: [userId], references: [id])
   userId    Int?
 }
 


### PR DESCRIPTION
## Summary
- extend Prisma schema with roles, comment status, and user profile fields
- allow public signup with optional toggle and navigation links
- add comment moderation, profile editing, and role-based access

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c489bc528883338db58e7277a11aa9