### PR TITLE
Fix logout redirect to use current host

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -25,7 +25,12 @@ const NavBar = () => {
           <>
             <Link href="/profile">Profil</Link>
             {session.user?.role === 'ADMIN' && <Link href="/admin">Backend</Link>}
-            <button onClick={() => signOut()} className="text-blue-600 dark:text-blue-400">Logout</button>
+            <button
+              onClick={() => signOut({ callbackUrl: window.location.origin })}
+              className="text-blue-600 dark:text-blue-400"
+            >
+              Logout
+            </button>
           </>
         ) : (
           <>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -14,6 +14,7 @@ export default function MyApp({ Component, pageProps: { session, ...pageProps } 
   const [siteName, setSiteName] = useState('NewsBlogCMS');
   const [theme, setTheme] = useState<Theme>('light');
   const [maintenance, setMaintenance] = useState(false);
+  const [authBaseUrl, setAuthBaseUrl] = useState('');
 
   useEffect(() => {
     const fetchSettings = () => {
@@ -40,6 +41,12 @@ export default function MyApp({ Component, pageProps: { session, ...pageProps } 
     }
   }, []);
 
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setAuthBaseUrl(window.location.origin);
+    }
+  }, []);
+
   const toggleTheme = () => {
     const newTheme = theme === 'light' ? 'dark' : 'light';
     setTheme(newTheme);
@@ -58,7 +65,7 @@ export default function MyApp({ Component, pageProps: { session, ...pageProps } 
   }
 
   return (
-    <SessionProvider session={session}>
+    <SessionProvider session={session} baseUrl={authBaseUrl}>
       <SiteContext.Provider value={{ siteName }}>
         <ThemeContext.Provider value={{ theme, toggleTheme }}>
           <Head>


### PR DESCRIPTION
## Summary
- ensure NextAuth uses current host as base URL
- redirect logout to the active origin

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c48c00f1748333bf5f916f8c88cff1