### PR TITLE
Use darker backgrounds for text fields in dark mode

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -9,4 +9,9 @@
   .dark body {
     @apply bg-gray-950 text-gray-100;
   }
+  input,
+  textarea,
+  select {
+    @apply bg-white text-gray-900 dark:bg-gray-800 dark:text-gray-100;
+  }
 }


### PR DESCRIPTION
## Summary
- Ensure text inputs, textareas and selects use a dark background and light text when dark mode is active

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c492da77808333bfddcbd08030d36e