### PR TITLE
feat: restart app after update

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "node scripts/clearMaintenance.js && next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "node scripts/clearMaintenance.js && next start",
     "lint": "next lint",
     "test": "echo \"No tests specified\" && exit 0",
     "prisma:migrate": "prisma migrate dev",

--- a/pages/api/update.ts
+++ b/pages/api/update.ts
@@ -44,6 +44,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       create: { key: 'maintenance', value: 'false' },
     });
     res.json({ status: 'updated' });
+    setTimeout(() => {
+      process.exit(0);
+    }, 1000);
   } catch (e) {
     await prisma.setting.upsert({
       where: { key: 'maintenance' },

--- a/scripts/clearMaintenance.js
+++ b/scripts/clearMaintenance.js
@@ -1,0 +1,19 @@
+const { PrismaClient } = require('@prisma/client');
+
+const prisma = new PrismaClient();
+
+async function clearMaintenance() {
+  await prisma.setting.upsert({
+    where: { key: 'maintenance' },
+    update: { value: 'false' },
+    create: { key: 'maintenance', value: 'false' },
+  });
+}
+
+clearMaintenance()
+  .catch((err) => {
+    console.error('Failed to clear maintenance flag', err);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- restart server automatically after update
- clear maintenance flag at startup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4944b310c83339486cdc6675750cc