### PR TITLE
Add user management and password reset features

### DIFF
--- a/components/AdminNav.tsx
+++ b/components/AdminNav.tsx
@@ -8,6 +8,7 @@ const AdminNav = () => {
       <Link href="/admin/tags">Tags</Link>
       <Link href="/admin/comments">Kommentare</Link>
       <Link href="/admin/settings">Einstellungen</Link>
+      <Link href="/admin/users">Benutzer</Link>
     </nav>
   );
 };

--- a/pages/admin/login.tsx
+++ b/pages/admin/login.tsx
@@ -7,6 +7,11 @@ const AdminLogin = () => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [allowSignup, setAllowSignup] = useState(false);
+  const [resetMode, setResetMode] = useState(false);
+  const [challenge, setChallenge] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [message, setMessage] = useState('');
   const router = useRouter();
 
   useEffect(() => {
@@ -17,19 +22,34 @@ const AdminLogin = () => {
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    const res = await signIn('credentials', {
-      redirect: false,
-      username,
-      password,
-    });
-    if (res && !res.error) {
-      router.push('/');
+    if (resetMode) {
+      const res = await fetch('/api/reset-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, challengePhrase: challenge, newPassword, confirmPassword: confirm }),
+      });
+      const data = await res.json();
+      setMessage(data.error || 'Passwort gesetzt');
+      if (!data.error) {
+        setResetMode(false);
+      }
+    } else {
+      const res = await signIn('credentials', {
+        redirect: false,
+        username,
+        password,
+      });
+      if (res && !res.error) {
+        router.push('/');
+      } else {
+        setMessage('Login fehlgeschlagen');
+      }
     }
   };
 
   return (
     <div className="p-4">
-      <h1 className="text-2xl font-bold">Login</h1>
+      <h1 className="text-2xl font-bold">{resetMode ? 'Passwort zurücksetzen' : 'Login'}</h1>
       <form onSubmit={handleSubmit} className="flex flex-col gap-2 max-w-sm mt-4">
         <input
           type="text"
@@ -38,18 +58,49 @@ const AdminLogin = () => {
           onChange={(e) => setUsername(e.target.value)}
           className="border p-2"
         />
-        <input
-          type="password"
-          placeholder="Passwort"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          className="border p-2"
-        />
+        {!resetMode && (
+          <input
+            type="password"
+            placeholder="Passwort"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="border p-2"
+          />
+        )}
+        {resetMode && (
+          <>
+            <input
+              type="text"
+              placeholder="Challenge Phrase"
+              value={challenge}
+              onChange={(e) => setChallenge(e.target.value)}
+              className="border p-2"
+            />
+            <input
+              type="password"
+              placeholder="Neues Passwort"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              className="border p-2"
+            />
+            <input
+              type="password"
+              placeholder="Passwort bestätigen"
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              className="border p-2"
+            />
+          </>
+        )}
         <button type="submit" className="bg-blue-500 text-white p-2">
-          Login
+          {resetMode ? 'Zurücksetzen' : 'Login'}
         </button>
+        {message && <p className="text-sm mt-2">{message}</p>}
       </form>
-      {allowSignup && (
+      <button onClick={() => setResetMode(!resetMode)} className="mt-4 underline text-sm">
+        {resetMode ? 'Zum Login' : 'Passwort vergessen?'}
+      </button>
+      {allowSignup && !resetMode && (
         <p className="mt-4 text-sm">
           Noch kein Account?{' '}
           <Link href="/signup" className="text-blue-600 underline">

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -1,0 +1,104 @@
+import { getSession } from 'next-auth/react';
+import { useEffect, useState } from 'react';
+
+interface User {
+  id: number;
+  username: string;
+  email: string;
+  role: string;
+  name?: string | null;
+}
+
+const UsersPage = () => {
+  const [users, setUsers] = useState<User[]>([]);
+
+  const load = () => {
+    fetch('/api/users')
+      .then((res) => res.json())
+      .then(setUsers);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const updateRole = async (id: number, role: string) => {
+    await fetch('/api/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: id, role }),
+    });
+    load();
+  };
+
+  const del = async (id: number) => {
+    await fetch('/api/users', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: id }),
+    });
+    load();
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Benutzer</h1>
+      <table className="w-full border">
+        <thead>
+          <tr className="border-b">
+            <th className="p-2 text-left">Username</th>
+            <th className="p-2 text-left">Name</th>
+            <th className="p-2 text-left">E-Mail</th>
+            <th className="p-2 text-left">Rolle</th>
+            <th className="p-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((u) => (
+            <tr key={u.id} className="border-b">
+              <td className="p-2">{u.username}</td>
+              <td className="p-2">{u.name || ''}</td>
+              <td className="p-2">{u.email}</td>
+              <td className="p-2">
+                <select
+                  value={u.role}
+                  onChange={(e) => updateRole(u.id, e.target.value)}
+                  className="border p-1"
+                >
+                  <option value="GUEST">GUEST</option>
+                  <option value="USER">USER</option>
+                  <option value="AUTHOR">AUTHOR</option>
+                  <option value="MODERATOR">MODERATOR</option>
+                  <option value="ADMIN">ADMIN</option>
+                </select>
+              </td>
+              <td className="p-2 text-right">
+                <button
+                  onClick={() => del(u.id)}
+                  className="text-red-600"
+                >
+                  Löschen
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default UsersPage;
+
+export async function getServerSideProps(context: any) {
+  const session = await getSession(context);
+  if (!session || (session.user as any).role !== 'ADMIN') {
+    return {
+      redirect: {
+        destination: '/admin/login',
+        permanent: false,
+      },
+    };
+  }
+  return { props: {} };
+}

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -22,7 +22,7 @@ export const authOptions = {
         if (!user) return null;
         const isValid = await bcrypt.compare(credentials.password, user.password);
         if (!isValid) return null;
-        return { id: user.id.toString(), name: user.username, username: user.username, role: user.role };
+        return { id: user.id.toString(), name: user.name || user.username, username: user.username, role: user.role };
       },
     }),
   ],

--- a/pages/api/posts.ts
+++ b/pages/api/posts.ts
@@ -10,7 +10,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       include: {
         category: true,
         tags: true,
-        author: { select: { username: true } },
+        author: { select: { username: true, name: true } },
       },
       orderBy: { createdAt: 'desc' },
     });
@@ -36,7 +36,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       include: {
         category: true,
         tags: true,
-        author: { select: { username: true } },
+        author: { select: { username: true, name: true } },
       },
     });
     return res.json(post);

--- a/pages/api/profile.ts
+++ b/pages/api/profile.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth';
 import { authOptions } from './auth/[...nextauth]';
 import { prisma } from '../../lib/prisma';
+import bcrypt from 'bcryptjs';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions);
@@ -18,10 +19,24 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.json(user);
   }
   if (req.method === 'POST') {
-    const { name, bio, image } = req.body;
+    const { name, bio, image, challengePhrase, oldPassword, newPassword, confirmPassword } = req.body;
+    const data: any = { name, bio, image };
+    if (challengePhrase) {
+      data.challengePhrase = await bcrypt.hash(challengePhrase, 10);
+    }
+    if (oldPassword || newPassword || confirmPassword) {
+      if (!oldPassword || !newPassword || newPassword !== confirmPassword) {
+        return res.status(400).json({ error: 'Passwort ungültig' });
+      }
+      const user = await prisma.user.findUnique({ where: { id: userId } });
+      if (!user) return res.status(404).json({ error: 'User not found' });
+      const valid = await bcrypt.compare(oldPassword, user.password);
+      if (!valid) return res.status(400).json({ error: 'Falsches Passwort' });
+      data.password = await bcrypt.hash(newPassword, 10);
+    }
     await prisma.user.update({
       where: { id: userId },
-      data: { name, bio, image },
+      data,
     });
     return res.json({ status: 'ok' });
   }

--- a/pages/api/reset-password.ts
+++ b/pages/api/reset-password.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../lib/prisma';
+import bcrypt from 'bcryptjs';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).end();
+  }
+  const { username, challengePhrase, newPassword, confirmPassword } = req.body;
+  if (!username || !challengePhrase || !newPassword || newPassword !== confirmPassword) {
+    return res.status(400).json({ error: 'Ungültige Angaben' });
+  }
+  const user = await prisma.user.findUnique({ where: { username } });
+  if (!user || !user.challengePhrase) {
+    return res.status(400).json({ error: 'Reset nicht möglich' });
+  }
+  const valid = await bcrypt.compare(challengePhrase, user.challengePhrase);
+  if (!valid) {
+    return res.status(400).json({ error: 'Challenge falsch' });
+  }
+  const password = await bcrypt.hash(newPassword, 10);
+  await prisma.user.update({ where: { id: user.id }, data: { password } });
+  return res.json({ status: 'ok' });
+}

--- a/pages/api/users.ts
+++ b/pages/api/users.ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth';
+import { authOptions } from './auth/[...nextauth]';
+import { prisma } from '../../lib/prisma';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session || (session.user as any).role !== 'ADMIN') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  if (req.method === 'GET') {
+    const users = await prisma.user.findMany({
+      select: { id: true, username: true, email: true, role: true, name: true },
+    });
+    return res.json(users);
+  }
+  if (req.method === 'POST') {
+    const { userId, role } = req.body;
+    await prisma.user.update({ where: { id: Number(userId) }, data: { role } });
+    return res.json({ status: 'ok' });
+  }
+  if (req.method === 'DELETE') {
+    const { userId } = req.body;
+    await prisma.user.delete({ where: { id: Number(userId) } });
+    return res.json({ status: 'deleted' });
+  }
+  res.status(405).end();
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ interface Post {
   slug: string;
   createdAt: string;
   updatedAt: string;
-  author?: { username: string } | null;
+  author?: { username: string; name: string | null } | null;
   category?: { name: string } | null;
   tags: { id: number; name: string }[];
 }
@@ -26,7 +26,7 @@ const Home: NextPage<HomeProps> = ({ posts }) => {
             <Link href={`/news/${post.slug}`}>{post.title}</Link>
           </h2>
           <p className="text-sm text-gray-500">
-            {new Date(post.createdAt).toLocaleDateString()} | Autor: {post.author?.username || 'Unbekannt'} |
+            {new Date(post.createdAt).toLocaleDateString()} | Autor: {post.author?.name || post.author?.username || 'Unbekannt'} |
             Kategorie: {post.category?.name || 'Keine'}
           </p>
           {post.tags.length > 0 && (
@@ -44,7 +44,7 @@ const Home: NextPage<HomeProps> = ({ posts }) => {
 export const getServerSideProps: GetServerSideProps<HomeProps> = async () => {
   const posts = await prisma.post.findMany({
     include: {
-      author: { select: { username: true } },
+      author: { select: { username: true, name: true } },
       category: true,
       tags: true,
     },

--- a/pages/news/[slug].tsx
+++ b/pages/news/[slug].tsx
@@ -11,7 +11,7 @@ interface PostPageProps {
     slug: string;
     createdAt: string;
     updatedAt: string;
-    author?: { username: string } | null;
+    author?: { username: string; name: string | null } | null;
     category?: { name: string } | null;
     tags: { id: number; name: string }[];
   } | null;
@@ -23,7 +23,7 @@ const NewsPost = ({ post }: PostPageProps) => {
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-2">{post.title}</h1>
       <p className="text-sm text-gray-500 mb-4">
-        {new Date(post.createdAt).toLocaleDateString()} | Autor: {post.author?.username || 'Unbekannt'} | Kategorie: {post.category?.name || 'Keine'}
+        {new Date(post.createdAt).toLocaleDateString()} | Autor: {post.author?.name || post.author?.username || 'Unbekannt'} | Kategorie: {post.category?.name || 'Keine'}
       </p>
       {post.tags.length > 0 && (
         <p className="text-sm mb-4">Tags: {post.tags.map((t) => t.name).join(', ')}</p>
@@ -42,7 +42,7 @@ export const getServerSideProps: GetServerSideProps<PostPageProps> = async (cont
   const post = await prisma.post.findUnique({
     where: { slug },
     include: {
-      author: { select: { username: true } },
+      author: { select: { username: true, name: true } },
       category: true,
       tags: true,
     },

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -9,6 +9,11 @@ const Profile = () => {
   const [bio, setBio] = useState('');
   const [image, setImage] = useState('');
   const [saved, setSaved] = useState(false);
+  const [challenge, setChallenge] = useState('');
+  const [oldPassword, setOldPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [error, setError] = useState('');
 
   useEffect(() => {
     fetch('/api/profile')
@@ -22,13 +27,31 @@ const Profile = () => {
 
   const save = async (e: FormEvent) => {
     e.preventDefault();
-    await fetch('/api/profile', {
+    setError('');
+    const res = await fetch('/api/profile', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, bio, image }),
+      body: JSON.stringify({
+        name,
+        bio,
+        image,
+        challengePhrase: challenge,
+        oldPassword,
+        newPassword,
+        confirmPassword: confirm,
+      }),
     });
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
+    const data = await res.json();
+    if (data.error) {
+      setError(data.error);
+    } else {
+      setSaved(true);
+      setChallenge('');
+      setOldPassword('');
+      setNewPassword('');
+      setConfirm('');
+      setTimeout(() => setSaved(false), 2000);
+    }
   };
 
   return (
@@ -53,8 +76,36 @@ const Profile = () => {
           value={image}
           onChange={(e) => setImage(e.target.value)}
         />
+        <input
+          className="border p-2"
+          placeholder="Challenge Phrase"
+          value={challenge}
+          onChange={(e) => setChallenge(e.target.value)}
+        />
+        <input
+          type="password"
+          className="border p-2"
+          placeholder="Altes Passwort"
+          value={oldPassword}
+          onChange={(e) => setOldPassword(e.target.value)}
+        />
+        <input
+          type="password"
+          className="border p-2"
+          placeholder="Neues Passwort"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+        />
+        <input
+          type="password"
+          className="border p-2"
+          placeholder="Passwort bestätigen"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+        />
         <button className="bg-blue-500 text-white p-2">Speichern</button>
         {saved && <p className="text-green-600">Gespeichert!</p>}
+        {error && <p className="text-red-600">{error}</p>}
       </form>
       <div>
         <span className="mr-2">Modus:</span>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model User {
   name     String?
   bio      String?
   image    String?
+  challengePhrase String?
   comments Comment[]
   posts    Post[]
 }


### PR DESCRIPTION
## Summary
- support challenge phrase on user profile and password change with old password
- allow password reset via login dialog using challenge phrase
- add admin user management to delete users or change roles
- show profile display name in author fields

## Testing
- `npx prisma generate`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c49875e74483338d657785c1684782