### PR TITLE
Handle non-JSON signup errors

### DIFF
--- a/pages/api/signup.ts
+++ b/pages/api/signup.ts
@@ -4,7 +4,7 @@ import bcrypt from 'bcryptjs';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
-    return res.status(405).end();
+    return res.status(405).json({ error: 'Method not allowed' });
   }
 
   const setting = await prisma.setting.findUnique({ where: { key: 'allowSignup' } });

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -11,16 +11,27 @@ const Signup = ({ allowSignup }: { allowSignup: boolean }) => {
 
   const submit = async (e: FormEvent) => {
     e.preventDefault();
-    const res = await fetch('/api/signup', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, email, password }),
-    });
-    if (res.ok) {
-      router.push('/admin/login');
-    } else {
-      const data = await res.json();
-      setError(data.error || 'Fehler');
+    setError('');
+    try {
+      const res = await fetch('/api/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, email, password }),
+      });
+      if (res.ok) {
+        router.push('/admin/login');
+      } else {
+        let message = 'Fehler';
+        try {
+          const data = await res.json();
+          message = data.error || message;
+        } catch {
+          // Antwort ist kein JSON
+        }
+        setError(message);
+      }
+    } catch {
+      setError('Netzwerkfehler');
     }
   };
 


### PR DESCRIPTION
## Summary
- return JSON error for disallowed HTTP methods in signup API
- harden signup form submission against non-JSON responses

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c49b6657888333bc5f8c0ef1b67a2b