### PR TITLE
feat: add role-based menus and post editing

### DIFF
--- a/components/AdminNav.tsx
+++ b/components/AdminNav.tsx
@@ -1,14 +1,22 @@
 import Link from 'next/link';
+import { useSession } from 'next-auth/react';
 
 const AdminNav = () => {
+  const { data: session } = useSession();
+  const role = session?.user?.role;
+
   return (
     <nav className="flex gap-4 mb-4">
-      <Link href="/admin/posts">Posts</Link>
-      <Link href="/admin/categories">Kategorien</Link>
-      <Link href="/admin/tags">Tags</Link>
-      <Link href="/admin/comments">Kommentare</Link>
-      <Link href="/admin/settings">Einstellungen</Link>
-      <Link href="/admin/users">Benutzer</Link>
+      {(role === 'ADMIN' || role === 'AUTHOR') && (
+        <Link href="/admin/posts">Posts</Link>
+      )}
+      {role === 'ADMIN' && <Link href="/admin/categories">Kategorien</Link>}
+      {role === 'ADMIN' && <Link href="/admin/tags">Tags</Link>}
+      {(role === 'ADMIN' || role === 'MODERATOR') && (
+        <Link href="/admin/comments">Kommentare</Link>
+      )}
+      {role === 'ADMIN' && <Link href="/admin/settings">Einstellungen</Link>}
+      {role === 'ADMIN' && <Link href="/admin/users">Benutzer</Link>}
     </nav>
   );
 };

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -25,6 +25,12 @@ const NavBar = () => {
           <>
             <Link href="/profile">Profil</Link>
             {session.user?.role === 'ADMIN' && <Link href="/admin">Backend</Link>}
+            {session.user?.role === 'AUTHOR' && (
+              <Link href="/admin/posts">Beiträge</Link>
+            )}
+            {session.user?.role === 'MODERATOR' && (
+              <Link href="/admin/comments">Moderation</Link>
+            )}
             <button
               onClick={async () => {
                 await signOut({ redirect: false });

--- a/components/PostList.tsx
+++ b/components/PostList.tsx
@@ -3,9 +3,25 @@ interface Post {
   title: string;
   category?: { name: string } | null;
   tags: { id: number; name: string }[];
+  authorId: number;
 }
 
-const PostList = ({ posts, onDelete }: { posts: Post[]; onDelete: (id: number) => void }) => {
+interface User {
+  id: number;
+  role: string;
+}
+
+const PostList = ({
+  posts,
+  onDelete,
+  onEdit,
+  currentUser,
+}: {
+  posts: Post[];
+  onDelete: (id: number) => void;
+  onEdit: (post: Post) => void;
+  currentUser: User;
+}) => {
   if (!posts.length) return <p>Keine Beiträge vorhanden.</p>;
   return (
     <ul className="flex flex-col gap-2">
@@ -20,12 +36,24 @@ const PostList = ({ posts, onDelete }: { posts: Post[]; onDelete: (id: number) =
               </p>
             )}
           </div>
-          <button
-            onClick={() => onDelete(post.id)}
-            className="text-red-600"
-          >
-            Löschen
-          </button>
+          <div className="flex gap-2">
+            {(currentUser.role === 'ADMIN' || currentUser.id === post.authorId) && (
+              <button
+                onClick={() => onEdit(post)}
+                className="text-blue-600"
+              >
+                Bearbeiten
+              </button>
+            )}
+            {(currentUser.role === 'ADMIN' || currentUser.id === post.authorId) && (
+              <button
+                onClick={() => onDelete(post.id)}
+                className="text-red-600"
+              >
+                Löschen
+              </button>
+            )}
+          </div>
         </li>
       ))}
     </ul>

--- a/pages/api/posts.ts
+++ b/pages/api/posts.ts
@@ -6,7 +6,18 @@ import { authOptions } from './auth/[...nextauth]';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
+    const session = await getServerSession(req, res, authOptions);
+    if (!session) return res.status(401).json({ error: 'Unauthorized' });
+    const role = (session.user as any).role;
+    if (!['ADMIN', 'AUTHOR'].includes(role)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    const where =
+      role === 'AUTHOR'
+        ? { authorId: Number((session.user as any).id) }
+        : undefined;
     const posts = await prisma.post.findMany({
+      where,
       include: {
         category: true,
         tags: true,
@@ -19,6 +30,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (req.method === 'POST') {
     const session = await getServerSession(req, res, authOptions);
     if (!session) return res.status(401).json({ error: 'Unauthorized' });
+    if (!['ADMIN', 'AUTHOR'].includes((session.user as any).role)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
     const { title, content, categoryId, tagIds } = req.body;
     const slug = slugify(title, { lower: true });
     const post = await prisma.post.create({

--- a/pages/api/posts/[id].ts
+++ b/pages/api/posts/[id].ts
@@ -1,8 +1,44 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { prisma } from '../../../lib/prisma';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+import slugify from 'slugify';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const id = Array.isArray(req.query.id) ? req.query.id[0] : req.query.id;
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) return res.status(401).json({ error: 'Unauthorized' });
+
+  const existing = await prisma.post.findUnique({ where: { id: Number(id) } });
+  if (!existing) return res.status(404).json({ error: 'Not found' });
+  const isOwner = existing.authorId === Number((session.user as any).id);
+  const isAdmin = (session.user as any).role === 'ADMIN';
+  if (!isOwner && !isAdmin) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  if (req.method === 'PUT') {
+    const { title, content, categoryId, tagIds } = req.body;
+    const slug = slugify(title, { lower: true });
+    const post = await prisma.post.update({
+      where: { id: Number(id) },
+      data: {
+        title,
+        content,
+        slug,
+        categoryId: categoryId ? Number(categoryId) : null,
+        tags: {
+          set: tagIds && tagIds.length ? tagIds.map((tid: number) => ({ id: tid })) : [],
+        },
+      },
+      include: {
+        category: true,
+        tags: true,
+        author: { select: { username: true, name: true } },
+      },
+    });
+    return res.json(post);
+  }
   if (req.method === 'DELETE') {
     await prisma.post.delete({ where: { id: Number(id) } });
     return res.json({ status: 'ok' });


### PR DESCRIPTION
## Summary
- show moderator and author menus in navigation
- allow authors to edit only their own posts while admins manage all
- protect post creation and update API endpoints with role checks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c49e74d1148333a7d15f145106d92d