### PR TITLE
Show only pending comments in moderation

### DIFF
--- a/pages/admin/comments.tsx
+++ b/pages/admin/comments.tsx
@@ -14,7 +14,7 @@ const AdminComments = () => {
   const [comments, setComments] = useState<Comment[]>([]);
 
   const load = async () => {
-    const res = await fetch('/api/comments');
+    const res = await fetch('/api/comments?status=PENDING');
     setComments(await res.json());
   };
 

--- a/pages/api/comments.ts
+++ b/pages/api/comments.ts
@@ -6,9 +6,18 @@ import { authOptions } from './auth/[...nextauth]';
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions);
   if (req.method === 'GET') {
-    const { postId } = req.query;
+    const { postId, status } = req.query;
     const where: any = postId ? { postId: Number(postId) } : {};
-    if (!session || !['MODERATOR', 'ADMIN'].includes((session.user as any).role)) {
+    if (
+      status &&
+      session &&
+      ['MODERATOR', 'ADMIN'].includes((session.user as any).role)
+    ) {
+      where.status = String(status);
+    } else if (
+      !session ||
+      !['MODERATOR', 'ADMIN'].includes((session.user as any).role)
+    ) {
       where.status = 'APPROVED';
     }
     const comments = await prisma.comment.findMany({


### PR DESCRIPTION
## Summary
- Filter comments API by status when requested by moderators
- Load only pending comments in admin moderation interface

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4a0eeada48333bceb564954577bd5