### PR TITLE
Add user profile page with author links

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -26,8 +26,13 @@ const Home: NextPage<HomeProps> = ({ posts }) => {
             <Link href={`/news/${post.slug}`}>{post.title}</Link>
           </h2>
           <p className="text-sm text-gray-500">
-            {new Date(post.createdAt).toLocaleDateString()} | Autor: {post.author?.name || post.author?.username || 'Unbekannt'} |
-            Kategorie: {post.category?.name || 'Keine'}
+            {new Date(post.createdAt).toLocaleDateString()} | Autor: {post.author ? (
+              <Link href={`/user/${post.author.username}`} className="text-blue-600">
+                {post.author.name || post.author.username}
+              </Link>
+            ) : (
+              'Unbekannt'
+            )} | Kategorie: {post.category?.name || 'Keine'}
           </p>
           {post.tags.length > 0 && (
             <p className="text-sm">Tags: {post.tags.map((t) => t.name).join(', ')}</p>

--- a/pages/news/[slug].tsx
+++ b/pages/news/[slug].tsx
@@ -23,7 +23,13 @@ const NewsPost = ({ post }: PostPageProps) => {
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-2">{post.title}</h1>
       <p className="text-sm text-gray-500 mb-4">
-        {new Date(post.createdAt).toLocaleDateString()} | Autor: {post.author?.name || post.author?.username || 'Unbekannt'} | Kategorie: {post.category?.name || 'Keine'}
+        {new Date(post.createdAt).toLocaleDateString()} | Autor: {post.author ? (
+          <Link href={`/user/${post.author.username}`} className="text-blue-600">
+            {post.author.name || post.author.username}
+          </Link>
+        ) : (
+          'Unbekannt'
+        )} | Kategorie: {post.category?.name || 'Keine'}
       </p>
       {post.tags.length > 0 && (
         <p className="text-sm mb-4">Tags: {post.tags.map((t) => t.name).join(', ')}</p>

--- a/pages/user/[username].tsx
+++ b/pages/user/[username].tsx
@@ -1,0 +1,96 @@
+import { GetServerSideProps } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import { prisma } from '../../lib/prisma';
+
+interface UserProfileProps {
+  user:
+    | {
+        username: string;
+        name: string | null;
+        bio: string | null;
+        image: string | null;
+        role: string;
+        createdAt: string;
+        posts: { id: number; title: string; slug: string }[];
+      }
+    | null;
+}
+
+const UserProfile = ({ user }: UserProfileProps) => {
+  if (!user) return <div className="p-4">Benutzer nicht gefunden.</div>;
+  return (
+    <div className="p-4 max-w-2xl mx-auto">
+      <div className="flex items-center gap-4 mb-6">
+        {user.image ? (
+          <Image
+            src={user.image}
+            alt={user.name || user.username}
+            width={96}
+            height={96}
+            className="w-24 h-24 rounded-full object-cover"
+          />
+        ) : (
+          <div className="w-24 h-24 rounded-full bg-gray-300 flex items-center justify-center text-2xl">
+            {user.name?.[0] || user.username[0]}
+          </div>
+        )}
+        <div>
+          <h1 className="text-2xl font-bold">{user.name || user.username}</h1>
+          <p className="text-gray-500">
+            Registriert seit {new Date(user.createdAt).toLocaleDateString()}
+          </p>
+          <p className="text-gray-500">Gruppe: {user.role}</p>
+        </div>
+      </div>
+      {user.bio && <p className="mb-6">{user.bio}</p>}
+      <h2 className="text-xl font-semibold mb-2">Beiträge</h2>
+      {user.posts.length ? (
+        <ul className="list-disc pl-5 space-y-1">
+          {user.posts.map((post) => (
+            <li key={post.id}>
+              <Link href={`/news/${post.slug}`} className="text-blue-600">
+                {post.title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>Keine Beiträge vorhanden.</p>
+      )}
+    </div>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps<UserProfileProps> = async (
+  context
+) => {
+  const username = context.params?.username as string;
+  const user = await prisma.user.findUnique({
+    where: { username },
+    include: {
+      posts: {
+        select: { id: true, title: true, slug: true, createdAt: true },
+        orderBy: { createdAt: 'desc' },
+      },
+    },
+  });
+  return {
+    props: {
+      user: user
+        ? {
+            ...user,
+            createdAt: user.createdAt.toISOString(),
+            posts: user.posts.map((p) => ({
+              id: p.id,
+              title: p.title,
+              slug: p.slug,
+            })),
+          }
+        : null,
+    },
+  };
+};
+
+export default UserProfile;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,7 @@ model User {
   bio      String?
   image    String?
   challengePhrase String?
+  createdAt DateTime @default(now())
   comments Comment[]
   posts    Post[]
 }


### PR DESCRIPTION
## Summary
- Add dynamic user profile page displaying avatar, registration date, role and posts
- Link post author names to the corresponding profile page
- Track user registration date in schema

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Type error in pages/admin/posts.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a1c6374c8333bdd78a63fb2da217