### PR TITLE
Fix EditorJS layout reset and post parsing error

### DIFF
--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -9,7 +9,10 @@ interface EditorProps {
 
 const Editor = ({ data, onChange }: EditorProps) => {
   const editorRef = useRef<EditorJS | null>(null);
+  const hasRendered = useRef(false);
 
+  // Initialize editor once
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     let isMounted = true;
     (async () => {
@@ -33,8 +36,9 @@ const Editor = ({ data, onChange }: EditorProps) => {
   }, []);
 
   useEffect(() => {
-    if (data && editorRef.current) {
+    if (editorRef.current && data && !hasRendered.current) {
       editorRef.current.render(data);
+      hasRendered.current = true;
     }
   }, [data]);
 

--- a/pages/news/[slug].tsx
+++ b/pages/news/[slug].tsx
@@ -55,12 +55,22 @@ export const getServerSideProps: GetServerSideProps<PostPageProps> = async (cont
     },
   });
   const parser = edjsHTML();
+  const parsedContent = post
+    ? parser.parse(
+        typeof post.content === 'string'
+          ? JSON.parse(post.content)
+          : (post.content as any)
+      )
+    : '';
+  const htmlContent = Array.isArray(parsedContent)
+    ? parsedContent.join('')
+    : parsedContent;
   return {
     props: {
       post: post
         ? {
             ...post,
-            content: parser.parse(post.content as any).join(''),
+            content: htmlContent,
             createdAt: post.createdAt.toISOString(),
             updatedAt: post.updatedAt.toISOString(),
           }


### PR DESCRIPTION
## Summary
- prevent EditorJS from re-rendering on every change to keep layout stable
- parse stored post content safely when rendering posts

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4aa5559e8833383326d3149c7187b