### PR TITLE
feat: add profile tabs

### DIFF
--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -3,8 +3,9 @@ import { useContext, useEffect, useState, FormEvent } from 'react';
 import { ThemeContext } from '../lib/ThemeContext';
 
 const Profile = () => {
-  const { data: session } = useSession();
+  useSession();
   const { theme, toggleTheme } = useContext(ThemeContext);
+  const [tab, setTab] = useState<'profile' | 'option' | 'password'>('profile');
   const [name, setName] = useState('');
   const [bio, setBio] = useState('');
   const [image, setImage] = useState('');
@@ -25,16 +26,30 @@ const Profile = () => {
       });
   }, []);
 
-  const save = async (e: FormEvent) => {
+  const saveProfile = async (e: FormEvent) => {
+    e.preventDefault();
+    setError('');
+    const res = await fetch('/api/profile', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, bio, image }),
+    });
+    const data = await res.json();
+    if (data.error) {
+      setError(data.error);
+    } else {
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    }
+  };
+
+  const savePassword = async (e: FormEvent) => {
     e.preventDefault();
     setError('');
     const res = await fetch('/api/profile', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        name,
-        bio,
-        image,
         challengePhrase: challenge,
         oldPassword,
         newPassword,
@@ -57,65 +72,111 @@ const Profile = () => {
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Profil</h1>
-      <form onSubmit={save} className="flex flex-col gap-2 max-w-sm">
-        <input
-          className="border p-2"
-          placeholder="Name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-        />
-        <textarea
-          className="border p-2"
-          placeholder="Bio"
-          value={bio}
-          onChange={(e) => setBio(e.target.value)}
-        />
-        <input
-          className="border p-2"
-          placeholder="Bild-URL"
-          value={image}
-          onChange={(e) => setImage(e.target.value)}
-        />
-        <input
-          className="border p-2"
-          placeholder="Challenge Phrase"
-          value={challenge}
-          onChange={(e) => setChallenge(e.target.value)}
-        />
-        <input
-          type="password"
-          className="border p-2"
-          placeholder="Altes Passwort"
-          value={oldPassword}
-          onChange={(e) => setOldPassword(e.target.value)}
-        />
-        <input
-          type="password"
-          className="border p-2"
-          placeholder="Neues Passwort"
-          value={newPassword}
-          onChange={(e) => setNewPassword(e.target.value)}
-        />
-        <input
-          type="password"
-          className="border p-2"
-          placeholder="Passwort bestätigen"
-          value={confirm}
-          onChange={(e) => setConfirm(e.target.value)}
-        />
-        <button className="bg-blue-500 text-white p-2">Speichern</button>
-        {saved && <p className="text-green-600">Gespeichert!</p>}
-        {error && <p className="text-red-600">{error}</p>}
-      </form>
-      <div>
-        <span className="mr-2">Modus:</span>
+      <div className="flex gap-4 border-b">
         <button
-          onClick={toggleTheme}
-          className="px-3 py-1 border rounded bg-gray-100 dark:bg-gray-800 dark:border-gray-700"
+          onClick={() => setTab('profile')}
+          className={`pb-2 ${tab === 'profile' ? 'border-b-2 border-blue-500' : ''}`}
         >
-          {theme === 'light' ? 'Dark Mode' : 'Light Mode'}
+          Profil
+        </button>
+        <button
+          onClick={() => setTab('option')}
+          className={`pb-2 ${tab === 'option' ? 'border-b-2 border-blue-500' : ''}`}
+        >
+          Option
+        </button>
+        <button
+          onClick={() => setTab('password')}
+          className={`pb-2 ${tab === 'password' ? 'border-b-2 border-blue-500' : ''}`}
+        >
+          Passwort
         </button>
       </div>
+
+      {tab === 'profile' && (
+        <form onSubmit={saveProfile} className="flex flex-col gap-2 max-w-sm">
+          <input
+            className="border p-2"
+            placeholder="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <textarea
+            className="border p-2"
+            placeholder="Bio"
+            value={bio}
+            onChange={(e) => setBio(e.target.value)}
+          />
+          <input
+            className="border p-2"
+            placeholder="Avatar-URL"
+            value={image}
+            onChange={(e) => setImage(e.target.value)}
+          />
+          <button className="bg-blue-500 text-white p-2">Speichern</button>
+          {saved && <p className="text-green-600">Gespeichert!</p>}
+          {error && <p className="text-red-600">{error}</p>}
+        </form>
+      )}
+
+      {tab === 'option' && (
+        <div className="space-y-2">
+          <p className="mb-2">Light/Dark Mode</p>
+          <button
+            onClick={toggleTheme}
+            className="px-3 py-1 border rounded bg-gray-100 dark:bg-gray-800 dark:border-gray-700"
+          >
+            {theme === 'light' ? 'Dark Mode' : 'Light Mode'}
+          </button>
+        </div>
+      )}
+
+      {tab === 'password' && (
+        <form onSubmit={savePassword} className="flex flex-col gap-2 max-w-sm">
+          <div>
+            <label className="font-semibold">Challenge Phrase</label>
+            <p className="text-sm text-gray-600 mb-1">
+              Eine geheime Phrase, um deine Identität z. B. beim Zurücksetzen des Passworts zu bestätigen.
+            </p>
+            <input
+              className="border p-2 w-full"
+              placeholder="Challenge Phrase"
+              value={challenge}
+              onChange={(e) => setChallenge(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="font-semibold">Passwort ändern</label>
+            <p className="text-sm text-gray-600 mb-1">
+              Ändere hier dein aktuelles Passwort.
+            </p>
+          </div>
+          <input
+            type="password"
+            className="border p-2"
+            placeholder="Altes Passwort"
+            value={oldPassword}
+            onChange={(e) => setOldPassword(e.target.value)}
+          />
+          <input
+            type="password"
+            className="border p-2"
+            placeholder="Neues Passwort"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+          />
+          <input
+            type="password"
+            className="border p-2"
+            placeholder="Passwort bestätigen"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+          />
+          <button className="bg-blue-500 text-white p-2">Speichern</button>
+          {saved && <p className="text-green-600">Gespeichert!</p>}
+          {error && <p className="text-red-600">{error}</p>}
+        </form>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add tabbed navigation to profile page for profile, option, and password settings
- enable theme switching in option tab
- separate challenge phrase and password change with descriptions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5259ee234833395362e94bae51999