### PR TITLE
Add emergency maintenance release endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 DATABASE_URL="postgresql://USER:PASSWORD@localhost:5432/newsbook"
 NEXTAUTH_URL="http://localhost:3000"
 NEXTAUTH_SECRET="changeme"
+
+MAINTENANCE_RELEASE_SECRET=change-me

--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ npx next dev -H 0.0.0.0 -p 3000
 
 The app will then be available at `http://localhost:3000`.
 
+## Maintenance Mode
+
+When running the `/api/update` endpoint the site enters maintenance mode. If an update
+fails and the flag is not reset, you can clear it using an emergency release endpoint:
+
+```bash
+curl -X POST "http://localhost:3000/api/maintenance/release?secret=YOUR_SECRET"
+```
+
+Set `MAINTENANCE_RELEASE_SECRET` in your environment to protect the endpoint.
+
 ## Admin Test Account
 
 The seed creates an admin user with username `admin` and password `admin`. The admin area is available at `/admin`.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "node scripts/clearMaintenance.js && next start",
     "lint": "next lint",
     "test": "echo \"No tests specified\" && exit 0",
+    "maintenance:release": "node scripts/clearMaintenance.js",
     "prisma:migrate": "prisma migrate dev",
     "prisma:generate": "prisma generate",
     "prisma:seed": "node prisma/seed.js"

--- a/pages/api/maintenance/release.ts
+++ b/pages/api/maintenance/release.ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../../lib/prisma';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).end();
+  }
+  const secret = process.env.MAINTENANCE_RELEASE_SECRET;
+  const provided = Array.isArray(req.query.secret) ? req.query.secret[0] : req.query.secret;
+  if (!secret || provided !== secret) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  await prisma.setting.upsert({
+    where: { key: 'maintenance' },
+    update: { value: 'false' },
+    create: { key: 'maintenance', value: 'false' },
+  });
+
+  return res.status(200).json({ released: true });
+}


### PR DESCRIPTION
## Summary
- add API endpoint for clearing maintenance flag with secret
- document maintenance release and environment variable
- include npm script to reset maintenance status

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c5299c408c8333be553f8f5ce11b50