### PR TITLE
Handle avatar uploads with extension-based formats

### DIFF
--- a/pages/admin/settings.tsx
+++ b/pages/admin/settings.tsx
@@ -93,7 +93,7 @@ const AdminSettings = () => {
         />
         <input
           className="border p-2"
-          placeholder="Erlaubte Avatar-Formate (MIME, Komma getrennt)"
+          placeholder="Erlaubte Avatar-Formate (MIME oder Dateiendungen, Komma getrennt)"
           value={avatarAllowedFormats}
           onChange={(e) => setAvatarAllowedFormats(e.target.value)}
         />


### PR DESCRIPTION
## Summary
- allow avatar uploads using MIME or extension formats
- clarify settings placeholder for avatar formats

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c540b475808333b1e7503dd9e418e3