### PR TITLE
Fix avatar upload by normalizing Formidable file arrays

### DIFF
--- a/pages/api/profile.ts
+++ b/pages/api/profile.ts
@@ -80,9 +80,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         });
       });
 
-      const name = (fields.name as string) || undefined;
-      const bio = (fields.bio as string) || undefined;
-      const file = files.image as formidable.File | undefined;
+        const name = (fields.name as string) || undefined;
+        const bio = (fields.bio as string) || undefined;
+        const fileData = files.image;
+        const file = Array.isArray(fileData)
+          ? (fileData[0] as formidable.File)
+          : (fileData as formidable.File | undefined);
 
       debug('parsed form', {
         fields,


### PR DESCRIPTION
## Summary
- handle `formidable`'s file array when processing avatar uploads

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c548aa4cf48333a4db67cad3758172