### PR TITLE
Add GDPR-compliant tracking consent banner

### DIFF
--- a/components/ConsentBanner.tsx
+++ b/components/ConsentBanner.tsx
@@ -1,0 +1,35 @@
+import { useContext } from 'react';
+import { LocaleContext } from '../lib/LocaleContext';
+import { t } from '../lib/i18n';
+
+interface Props {
+  onAccept: () => void;
+  onDecline: () => void;
+}
+
+const ConsentBanner = ({ onAccept, onDecline }: Props) => {
+  const { locale } = useContext(LocaleContext);
+  return (
+    <div className="fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded shadow-md max-w-md text-center">
+        <p className="mb-4">{t(locale, 'consent_message')}</p>
+        <div className="flex justify-center gap-4">
+          <button
+            onClick={onAccept}
+            className="px-4 py-2 bg-blue-600 text-white rounded"
+          >
+            {t(locale, 'consent_accept')}
+          </button>
+          <button
+            onClick={onDecline}
+            className="px-4 py-2 bg-gray-300 dark:bg-gray-700 rounded"
+          >
+            {t(locale, 'consent_decline')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConsentBanner;

--- a/locales/de.json
+++ b/locales/de.json
@@ -128,5 +128,8 @@
   "user_group": "Gruppe:",
   "user_posts_title": "Beiträge",
   "user_posts_none": "Keine Beiträge vorhanden.",
-  "maintenance_message": "Bin gleich zurück..."
+  "maintenance_message": "Bin gleich zurück...",
+  "consent_message": "Wir erheben Nutzungsstatistiken, um Inhalte korrekt darzustellen. Wenn du das ablehnst, kannst du die Seite leider nicht nutzen.",
+  "consent_accept": "Akzeptieren",
+  "consent_decline": "Ablehnen"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -128,5 +128,8 @@
   "user_group": "Group:",
   "user_posts_title": "Posts",
   "user_posts_none": "No posts available.",
-  "maintenance_message": "Be right back..."
+  "maintenance_message": "Be right back...",
+  "consent_message": "We collect usage statistics to display content correctly. If you decline, you cannot use the site.",
+  "consent_accept": "Accept",
+  "consent_decline": "Decline"
 }

--- a/pages/api/consent.ts
+++ b/pages/api/consent.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../lib/prisma';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const ipHeader = (req.headers['x-forwarded-for'] as string) || req.socket.remoteAddress || '';
+  const ip = ipHeader.split(',')[0].trim();
+
+  if (req.method === 'GET') {
+    const existing = await prisma.trackingConsent.findUnique({ where: { ip } });
+    res.status(200).json({ consented: !!existing });
+    return;
+  }
+
+  if (req.method === 'POST') {
+    const { accept } = req.body || {};
+    if (accept) {
+      await prisma.trackingConsent.upsert({
+        where: { ip },
+        update: {},
+        create: { ip },
+      });
+      res.status(200).json({ consented: true });
+    } else {
+      res.status(200).json({ consented: false });
+    }
+    return;
+  }
+
+  res.status(405).end();
+}

--- a/pages/api/track.ts
+++ b/pages/api/track.ts
@@ -11,6 +11,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const ipHeader = (req.headers['x-forwarded-for'] as string) || req.socket.remoteAddress || '';
   const ip = ipHeader.split(',')[0].trim();
 
+  const consent = await prisma.trackingConsent.findUnique({ where: { ip } });
+  if (!consent) {
+    res.status(403).json({ ok: false });
+    return;
+  }
+
   let postId: number | undefined;
   const match = /^\/news\/([^/?#]+)/.exec(path);
   if (match) {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,3 +93,9 @@ model PageView {
   post      Post?    @relation(fields: [postId], references: [id])
   postId    Int?
 }
+
+model TrackingConsent {
+  id        Int      @id @default(autoincrement())
+  ip        String   @unique
+  createdAt DateTime @default(now())
+}


### PR DESCRIPTION
## Summary
- add TrackingConsent model and API to store per-IP consent
- gate page view tracking behind user consent and show banner
- provide EN/DE translations for consent message

## Testing
- `npm run prisma:generate`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c551133d74833388f09412aa300c4a