### PR TITLE
Use groupBy for unique page views

### DIFF
--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -68,7 +68,11 @@ export async function getServerSideProps(context: any) {
     };
   }
 
-  const uniqueViews = await prisma.pageView.count({ distinct: ['ip'] });
+  const uniqueViewsData = await prisma.pageView.groupBy({
+    by: ['ip'],
+    _count: { _all: true },
+  });
+  const uniqueViews = uniqueViewsData.length;
   const postsCount = await prisma.post.count();
   const commentsCount = await prisma.comment.count();
 


### PR DESCRIPTION
## Summary
- avoid `distinct` error by using `groupBy` to get unique page views

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5528ffa3483339899c95bc1b2c9f7