### PR TITLE
feat: add post previews

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -40,6 +40,7 @@
   "post_no_category": "Keine",
   "post_tags": "Tags:",
   "post_view_comments": "Kommentare ansehen",
+  "post_view_all": "Alles anzeigen",
   "post_not_found": "Beitrag nicht gefunden.",
   "post_back_home": "Zurück zur Startseite",
   "signup_error": "Fehler",

--- a/locales/en.json
+++ b/locales/en.json
@@ -40,6 +40,7 @@
   "post_no_category": "None",
   "post_tags": "Tags:",
   "post_view_comments": "View comments",
+  "post_view_all": "View all",
   "post_not_found": "Post not found.",
   "post_back_home": "Back to homepage",
   "signup_error": "Error",


### PR DESCRIPTION
## Summary
- show first 10 lines of each post on the homepage
- add translation for "View all"

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5544ad6308333b2627ca4a972b50e