### PR TITLE
Fix preview formatting and length

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -80,9 +80,13 @@ export const getServerSideProps: GetServerSideProps<HomeProps> = async () => {
           typeof p.content === 'string' ? JSON.parse(p.content) : (p.content as any)
         );
         const html = Array.isArray(parsed) ? parsed : [parsed];
-        const text = html.join('').replace(/<[^>]+>/g, '');
+        const text = html
+          .join(' ')
+          .replace(/<[^>]+>/g, '')
+          .replace(/\s+/g, ' ')
+          .trim();
         const previewText =
-          text.length > 150 ? text.slice(0, 150).trimEnd() + '...' : text;
+          text.length > 300 ? text.slice(0, 300).trimEnd() + '...' : text;
         return {
           ...p,
           createdAt: p.createdAt.toISOString(),


### PR DESCRIPTION
## Summary
- keep preview formatting by inserting spaces between parsed blocks and collapsing whitespace
- extend preview length to 300 characters

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5596f567c83339d8e8e958083a414